### PR TITLE
Add per-channel PB tracking

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -194,6 +194,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("./../src/content.config.mjs");
+	export type ContentConfig = typeof import("../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1751335141806
+		"lastUpdateCheck": 1753141217380
 	}
 }

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,11 +58,11 @@ import Twitch from '../components/Icons/Twitch.astro'
             <span id="level-value"></span>
           </div>
           <div>
-            <span id="pb-title">PB Level:</span>
+            <span id="pb-title">Highest Level:</span>
             <span id="pb-value"></span>
           </div>
           <div>
-            <span id="daily-pb-title">Daily PB Level:</span>
+            <span id="daily-pb-title">Today's Highest Level:</span>
             <span id="daily-pb-value"></span>
           </div>
           <div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,14 +58,6 @@ import Twitch from '../components/Icons/Twitch.astro'
             <span id="level-value"></span>
           </div>
           <div>
-            <span id="pb-title">Highest Level:</span>
-            <span id="pb-value"></span>
-          </div>
-          <div>
-            <span id="daily-pb-title">Today's Highest Level:</span>
-            <span id="daily-pb-value"></span>
-          </div>
-          <div>
             <span id="hidden-letter-label">Hidden Letters:</span>
             <span id="hidden-letter"></span>
           </div>
@@ -81,6 +73,14 @@ import Twitch from '../components/Icons/Twitch.astro'
           <div id="correct-words-log-container">
             <span>Correct Words: (* words missed)</span>
             <div id="correct-words-log" class="logs"></div>
+          </div>
+          <div>
+            <span id="pb-title">Highest Level:</span>
+            <span id="pb-value"></span>
+          </div>
+          <div>
+            <span id="daily-pb-title">Today's Highest Level:</span>
+            <span id="daily-pb-value"></span>
           </div>
         </div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,6 +58,14 @@ import Twitch from '../components/Icons/Twitch.astro'
             <span id="level-value"></span>
           </div>
           <div>
+            <span id="pb-title">PB Level:</span>
+            <span id="pb-value"></span>
+          </div>
+          <div>
+            <span id="daily-pb-title">Daily PB Level:</span>
+            <span id="daily-pb-value"></span>
+          </div>
+          <div>
             <span id="hidden-letter-label">Hidden Letters:</span>
             <span id="hidden-letter"></span>
           </div>

--- a/src/scripts/wos-worker.ts
+++ b/src/scripts/wos-worker.ts
@@ -14,6 +14,7 @@ export interface WosWorkerMessage {
     hiddenLetters?: string[];
     slots?: any[];
     index?: number;
+    record?: number;
   };
 }
 
@@ -55,25 +56,6 @@ self.onmessage = function (e: MessageEvent<WosWorkerMessage>) {
       slots: data.slots || [],
     };
 
-    const recordKeys = [
-      'record',
-      'recordLevel',
-      'bestLevel',
-      'best',
-      'topLevel',
-      'levelRecord',
-      'maxLevel',
-    ];
-    for (const key of recordKeys) {
-      if (data && data[key] !== undefined) {
-        const val = parseInt(data[key]);
-        if (!isNaN(val)) {
-          result.record = val;
-          break;
-        }
-      }
-    }
-
     // console.log(`[WOS Worker] Event Type: ${eventType}`, data);
 
     if (eventType === 1) {
@@ -104,6 +86,7 @@ self.onmessage = function (e: MessageEvent<WosWorkerMessage>) {
     } else if (eventType === 12) {
       currentLevel = data.level!;
       result.wosEventName = 'Game Connected';
+      result.record = data.record;
       self.postMessage(result);
     } else {
       console.log(`[WOS Worker] Unhandled WOS event type: ${eventType}`);

--- a/src/scripts/wos-worker.ts
+++ b/src/scripts/wos-worker.ts
@@ -25,6 +25,7 @@ export interface WosWorkerResult {
   letters: string[];
   stars: number;
   level: number;
+  record?: number;
   hitMax: boolean;
   falseLetters: string[];
   hiddenLetters: string[];
@@ -47,11 +48,31 @@ self.onmessage = function (e: MessageEvent<WosWorkerMessage>) {
       letters: data.letters || [],
       stars: data.stars || 0,
       level: data.level || 0,
+      record: undefined,
       hitMax: data.hitMax || false,
       falseLetters: data.falseLetters || [],
       hiddenLetters: data.hiddenLetters || [],
       slots: data.slots || [],
     };
+
+    const recordKeys = [
+      'record',
+      'recordLevel',
+      'bestLevel',
+      'best',
+      'topLevel',
+      'levelRecord',
+      'maxLevel',
+    ];
+    for (const key of recordKeys) {
+      if (data && data[key] !== undefined) {
+        const val = parseInt(data[key]);
+        if (!isNaN(val)) {
+          result.record = val;
+          break;
+        }
+      }
+    }
 
     // console.log(`[WOS Worker] Event Type: ${eventType}`, data);
 


### PR DESCRIPTION
## Summary
- track and persist the highest level achieved per Twitch channel
- show the personal best on the main game UI
- track daily personal best values as well

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868b0ba4e3483248e6d01d1f979c79c