### PR TITLE
Add toggle to control WoS board visibility from player settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4167,6 +4167,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
       "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4882,6 +4883,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5130,6 +5132,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -50,6 +50,20 @@ import SettingsDialog from '../components/SettingsDialog.astro';
         </label>
         <small class='form-help'>Toggle Twitch chat visibility</small>
       </div>
+      <div class='form-group'>
+        <label class='toggle-label'>
+          <input
+            type='checkbox'
+            id='wos-enabled-input'
+            name='wosEnabled'
+            class='toggle-input'
+            checked
+          />
+          <span class='toggle-slider'></span>
+          <span class='toggle-text'>Show Words on Stream</span>
+        </label>
+        <small class='form-help'>Toggle the Words on Stream board visibility</small>
+      </div>
     </form>
   </SettingsDialog>
 
@@ -266,6 +280,43 @@ import SettingsDialog from '../components/SettingsDialog.astro';
   // Initialize dialog API reference
   let settingsDialog: any = null;
 
+  const populateSettingsFormFromUrl = (urlParams: URLSearchParams) => {
+    const mirrorUrlInput = document.getElementById(
+      'mirror-url-input'
+    ) as HTMLInputElement | null;
+    const twitchChannelInput = document.getElementById(
+      'twitch-channel-input'
+    ) as HTMLInputElement | null;
+    const chatEnabledInput = document.getElementById(
+      'chat-enabled-input'
+    ) as HTMLInputElement | null;
+    const wosEnabledInput = document.getElementById(
+      'wos-enabled-input'
+    ) as HTMLInputElement | null;
+
+    if (mirrorUrlInput && urlParams.has('mirrorUrl')) {
+      mirrorUrlInput.value = urlParams.get('mirrorUrl') || '';
+    }
+
+    if (twitchChannelInput && urlParams.has('twitchChannel')) {
+      twitchChannelInput.value = urlParams.get('twitchChannel') || '';
+    }
+
+    if (chatEnabledInput) {
+      const chatParam = urlParams.get('chat');
+      chatEnabledInput.checked = chatParam
+        ? chatParam.toLowerCase() === 'true'
+        : true;
+    }
+
+    if (wosEnabledInput) {
+      const boardParam = urlParams.get('board');
+      wosEnabledInput.checked = boardParam
+        ? boardParam.toLowerCase() === 'true'
+        : true;
+    }
+  };
+
   const initializeSettingsDialog = (event?: Event) => {
     const dialog = document.getElementById(
       'player-settings'
@@ -293,6 +344,8 @@ import SettingsDialog from '../components/SettingsDialog.astro';
       }
       // Handle chat enabled toggle
       params.set('chat', data.chatEnabled ? 'true' : 'false');
+      // Handle WoS board visibility toggle
+      params.set('board', data.wosEnabled ? 'true' : 'false');
 
       // Navigate to the updated URL
       const newUrl = window.location.pathname + '?' + params.toString();
@@ -308,23 +361,7 @@ import SettingsDialog from '../components/SettingsDialog.astro';
     // If either parameter is missing, show the settings dialog
     if (!hasMirrorUrl || !hasTwitchChannel) {
       // Pre-populate any existing values
-      if (hasMirrorUrl) {
-        const mirrorUrlInput = document.getElementById(
-          'mirror-url-input'
-        ) as HTMLInputElement;
-        if (mirrorUrlInput) {
-          mirrorUrlInput.value = urlParams.get('mirrorUrl') || '';
-        }
-      }
-
-      if (hasTwitchChannel) {
-        const twitchChannelInput = document.getElementById(
-          'twitch-channel-input'
-        ) as HTMLInputElement;
-        if (twitchChannelInput) {
-          twitchChannelInput.value = urlParams.get('twitchChannel') || '';
-        }
-      }
+      populateSettingsFormFromUrl(urlParams);
 
       // Ensure dialog is ready and set up callbacks before opening
       const attemptOpenDialog = () => {
@@ -380,22 +417,7 @@ import SettingsDialog from '../components/SettingsDialog.astro';
         if (settingsDialog) {
           // Populate current values before opening
           const urlParams = new URLSearchParams(window.location.search);
-          const mirrorUrlInput = document.getElementById('mirror-url-input') as HTMLInputElement;
-          const twitchChannelInput = document.getElementById('twitch-channel-input') as HTMLInputElement;
-          const chatEnabledInput = document.getElementById('chat-enabled-input') as HTMLInputElement;
-          
-          if (mirrorUrlInput && urlParams.has('mirrorUrl')) {
-            mirrorUrlInput.value = urlParams.get('mirrorUrl') || '';
-          }
-          if (twitchChannelInput && urlParams.has('twitchChannel')) {
-            twitchChannelInput.value = urlParams.get('twitchChannel') || '';
-          }
-          if (chatEnabledInput) {
-            // Default to true if not specified
-            const chatParam = urlParams.get('chat');
-            chatEnabledInput.checked = chatParam ? chatParam.toLowerCase() === 'true' : true;
-          }
-          
+          populateSettingsFormFromUrl(urlParams);
           settingsDialog.open();
         }
       });
@@ -403,6 +425,7 @@ import SettingsDialog from '../components/SettingsDialog.astro';
 
     // check for query parameters in the url
     const urlParams = new URLSearchParams(window.location.search);
+    populateSettingsFormFromUrl(urlParams);
 
     // Check if required parameters are present (this will trigger dialog if needed)
     const hasRequiredParams = checkRequiredParams();

--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -60,7 +60,7 @@ import SettingsDialog from '../components/SettingsDialog.astro';
             checked
           />
           <span class='toggle-slider'></span>
-          <span class='toggle-text'>Show Words on Stream</span>
+          <span class='toggle-text'>Show Words on Stream Board</span>
         </label>
         <small class='form-help'>Toggle the Words on Stream board visibility</small>
       </div>


### PR DESCRIPTION
## Summary
- add a Words on Stream visibility toggle to the player settings dialog
- persist the toggle state via the `board` query parameter when saving
- centralize population of dialog inputs from the current URL parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69012faacd38832499f1a10cfb1cd1a5