### PR TITLE
Add Twitch account sign-in authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Supabase Configuration
+SUPABASE_URL=your_supabase_url
+SUPABASE_KEY=your_supabase_anon_key
+
+# Twitch OAuth Configuration
+# Create a Twitch application at https://dev.twitch.tv/console/apps
+TWITCH_CLIENT_ID=your_twitch_client_id
+TWITCH_CLIENT_SECRET=your_twitch_client_secret
+TWITCH_REDIRECT_URI=https://your-domain.com/api/auth/callback
+
+# JWT Secret for session management
+# Generate a random string (e.g., using: openssl rand -base64 32)
+JWT_SECRET=your_random_jwt_secret_at_least_32_characters

--- a/README.md
+++ b/README.md
@@ -4,3 +4,65 @@ This is a tool to assist with playing the game Words on Stream (WOS) and enhance
 
 A great summary of the tool and objective from [xScarletSagex](https://twitch.tv/xScarletSagex) on Twitch:
 this just automates tricks we already use for higher levels and solved the biggest issue where we wish we knew what words we missed
+
+## Setup
+
+### Prerequisites
+
+1. Node.js (v18 or higher)
+2. A Twitch account
+3. A Supabase account (for database)
+4. A Twitch application for OAuth
+
+### Environment Variables
+
+1. Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Fill in the environment variables:
+
+   **Supabase Configuration:**
+   - Get your Supabase URL and anon key from your Supabase project settings
+
+   **Twitch OAuth Configuration:**
+   - Create a Twitch application at https://dev.twitch.tv/console/apps
+   - Set the OAuth Redirect URL to: `https://your-domain.com/api/auth/callback`
+   - Copy the Client ID and Client Secret
+
+   **JWT Secret:**
+   - Generate a secure random string (at least 32 characters)
+   - You can use: `openssl rand -base64 32`
+
+3. For Cloudflare Workers deployment, set these as secrets:
+   ```bash
+   npx wrangler secret put SUPABASE_URL
+   npx wrangler secret put SUPABASE_KEY
+   npx wrangler secret put TWITCH_CLIENT_ID
+   npx wrangler secret put TWITCH_CLIENT_SECRET
+   npx wrangler secret put TWITCH_REDIRECT_URI
+   npx wrangler secret put JWT_SECRET
+   ```
+
+### Development
+
+```bash
+npm install
+npm run dev
+```
+
+### Deployment
+
+```bash
+npm run build
+npx wrangler deploy
+```
+
+## Features
+
+- **Twitch Authentication**: Secure sign-in with your Twitch account
+- **Player View**: Track words, personal bests, and game progress
+- **Streamer View**: Enhanced layout optimized for streaming
+- **Real-time Updates**: Live game state tracking
+- **Twitch Chat Integration**: Connect to Twitch chat for coordination

--- a/src/components/UserMenu.astro
+++ b/src/components/UserMenu.astro
@@ -1,0 +1,205 @@
+---
+interface Props {
+  username: string;
+  displayName: string;
+  profileImage: string;
+}
+
+const { username, displayName, profileImage } = Astro.props;
+---
+
+<div class="user-menu">
+  <button class="user-menu-trigger" id="user-menu-trigger">
+    <img src={profileImage} alt={displayName} class="user-avatar" />
+    <span class="user-name">{displayName}</span>
+    <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M4.427 6.573l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 6H4.604a.25.25 0 00-.177.573z"></path>
+    </svg>
+  </button>
+
+  <div class="user-menu-dropdown" id="user-menu-dropdown">
+    <div class="user-menu-header">
+      <img src={profileImage} alt={displayName} class="user-avatar-large" />
+      <div class="user-info">
+        <div class="user-display-name">{displayName}</div>
+        <div class="user-username">@{username}</div>
+      </div>
+    </div>
+    <div class="user-menu-divider"></div>
+    <a href="/api/auth/logout" class="user-menu-item logout">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+        <polyline points="16 17 21 12 16 7"></polyline>
+        <line x1="21" y1="12" x2="9" y2="12"></line>
+      </svg>
+      <span>Sign out</span>
+    </a>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('astro:page-load', () => {
+    const trigger = document.getElementById('user-menu-trigger');
+    const dropdown = document.getElementById('user-menu-dropdown');
+
+    if (!trigger || !dropdown) return;
+
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      dropdown.classList.toggle('show');
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!trigger.contains(e.target as Node) && !dropdown.contains(e.target as Node)) {
+        dropdown.classList.remove('show');
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        dropdown.classList.remove('show');
+      }
+    });
+  });
+</script>
+
+<style>
+  .user-menu {
+    position: relative;
+  }
+
+  .user-menu-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(139, 92, 246, 0.1);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    border-radius: 2rem;
+    color: rgba(255, 255, 255, 0.9);
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .user-menu-trigger:hover {
+    background: rgba(139, 92, 246, 0.2);
+    border-color: rgba(139, 92, 246, 0.4);
+  }
+
+  .user-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid rgba(139, 92, 246, 0.5);
+  }
+
+  .user-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chevron {
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+  }
+
+  .user-menu-trigger:hover .chevron {
+    transform: translateY(2px);
+  }
+
+  .user-menu-dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    min-width: 240px;
+    background: #1e1e2e;
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-0.5rem);
+    transition: all 0.2s ease;
+    z-index: 1000;
+    overflow: hidden;
+  }
+
+  .user-menu-dropdown.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .user-menu-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+
+  .user-avatar-large {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    border: 2px solid rgba(139, 92, 246, 0.5);
+  }
+
+  .user-info {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .user-display-name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.95);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .user-username {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.5);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .user-menu-divider {
+    height: 1px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .user-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    text-decoration: none;
+    color: rgba(255, 255, 255, 0.9);
+    transition: all 0.2s ease;
+  }
+
+  .user-menu-item:hover {
+    background: rgba(139, 92, 246, 0.1);
+  }
+
+  .user-menu-item.logout {
+    color: #f87171;
+  }
+
+  .user-menu-item.logout:hover {
+    background: rgba(248, 113, 113, 0.1);
+  }
+
+  @media (max-width: 640px) {
+    .user-name {
+      display: none;
+    }
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,12 +1,20 @@
 /// <reference types="astro/client" />
 
+import type { SessionUser } from './lib/auth';
+
 interface Env {
   SUPABASE_URL: string;
   SUPABASE_KEY: string;
+  TWITCH_CLIENT_ID: string;
+  TWITCH_CLIENT_SECRET: string;
+  TWITCH_REDIRECT_URI: string;
+  JWT_SECRET: string;
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 
 declare namespace App {
-  interface Locals extends Runtime { }
+  interface Locals extends Runtime {
+    user?: SessionUser;
+  }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,88 @@
+export interface SessionUser {
+  sub: string;
+  username: string;
+  display_name: string;
+  email?: string;
+  profile_image_url: string;
+  iat: number;
+  exp: number;
+}
+
+export async function verifySessionToken(
+  token: string,
+  secret: string
+): Promise<SessionUser | null> {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    const [headerB64, payloadB64, signatureB64] = parts;
+    const data = `${headerB64}.${payloadB64}`;
+
+    // Verify signature
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+
+    // Convert base64url to ArrayBuffer
+    const signatureBytes = Uint8Array.from(
+      atob(signatureB64.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - signatureB64.length % 4) % 4)),
+      c => c.charCodeAt(0)
+    );
+
+    const isValid = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      signatureBytes,
+      encoder.encode(data)
+    );
+
+    if (!isValid) {
+      return null;
+    }
+
+    // Decode payload
+    const payload = JSON.parse(
+      atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'))
+    ) as SessionUser;
+
+    // Check expiration
+    if (payload.exp < Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+
+    return payload;
+  } catch (error) {
+    console.error('Error verifying session token:', error);
+    return null;
+  }
+}
+
+export function getSessionFromRequest(request: Request): string | null {
+  const cookies = request.headers.get('cookie') || '';
+  const sessionCookie = cookies
+    .split(';')
+    .find(c => c.trim().startsWith('twitch_session='))
+    ?.split('=')[1];
+
+  return sessionCookie || null;
+}
+
+export async function getCurrentUser(
+  request: Request,
+  jwtSecret: string
+): Promise<SessionUser | null> {
+  const token = getSessionFromRequest(request);
+  if (!token) {
+    return null;
+  }
+
+  return verifySessionToken(token, jwtSecret);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { defineMiddleware } from 'astro:middleware';
+import { getCurrentUser } from './lib/auth';
+
+// Routes that require authentication
+const PROTECTED_ROUTES = ['/player', '/streamer'];
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { url, request, locals, redirect } = context;
+  const pathname = url.pathname;
+
+  // Check if this is a protected route
+  const isProtectedRoute = PROTECTED_ROUTES.some(route =>
+    pathname === route || pathname.startsWith(`${route}/`)
+  );
+
+  if (isProtectedRoute) {
+    const { env } = locals.runtime;
+    const jwtSecret = env.JWT_SECRET;
+
+    if (!jwtSecret) {
+      console.error('JWT_SECRET not configured');
+      return redirect('/signin?error=config_error');
+    }
+
+    const user = await getCurrentUser(request, jwtSecret);
+
+    if (!user) {
+      // Not authenticated, redirect to sign-in
+      return redirect(`/signin?redirect=${encodeURIComponent(pathname + url.search)}`);
+    }
+
+    // Store user in locals for use in pages
+    locals.user = user;
+  }
+
+  return next();
+});

--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -1,0 +1,161 @@
+import type { APIRoute } from 'astro';
+export const prerender = false;
+
+interface TwitchTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  scope: string[];
+  token_type: string;
+}
+
+interface TwitchUser {
+  id: string;
+  login: string;
+  display_name: string;
+  email?: string;
+  profile_image_url: string;
+}
+
+async function exchangeCodeForToken(
+  code: string,
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string
+): Promise<TwitchTokenResponse> {
+  const response = await fetch('https://id.twitch.tv/oauth2/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code: code,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to exchange code for token');
+  }
+
+  return response.json();
+}
+
+async function getTwitchUser(accessToken: string, clientId: string): Promise<TwitchUser> {
+  const response = await fetch('https://api.twitch.tv/helix/users', {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Client-Id': clientId,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Twitch user');
+  }
+
+  const data = await response.json();
+  return data.data[0];
+}
+
+async function createSessionToken(user: TwitchUser, secret: string): Promise<string> {
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+
+  const payload = {
+    sub: user.id,
+    username: user.login,
+    display_name: user.display_name,
+    email: user.email,
+    profile_image_url: user.profile_image_url,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60), // 7 days
+  };
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  const headerB64 = btoa(JSON.stringify(header)).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const payloadB64 = btoa(JSON.stringify(payload)).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const data = `${headerB64}.${payloadB64}`;
+
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(data)
+  );
+
+  const signatureB64 = btoa(String.fromCharCode(...new Uint8Array(signature)))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  return `${data}.${signatureB64}`;
+}
+
+export const GET: APIRoute = async ({ url, request, locals, redirect }) => {
+  const { env } = locals.runtime;
+
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  if (!code || !state) {
+    return redirect('/signin?error=invalid_request');
+  }
+
+  // Verify state from cookie
+  const cookies = request.headers.get('cookie') || '';
+  const stateCookie = cookies
+    .split(';')
+    .find(c => c.trim().startsWith('twitch_oauth_state='))
+    ?.split('=')[1];
+
+  if (!stateCookie || stateCookie !== state) {
+    return redirect('/signin?error=invalid_state');
+  }
+
+  try {
+    const clientId = env.TWITCH_CLIENT_ID;
+    const clientSecret = env.TWITCH_CLIENT_SECRET;
+    const redirectUri = env.TWITCH_REDIRECT_URI;
+    const jwtSecret = env.JWT_SECRET;
+
+    if (!clientId || !clientSecret || !redirectUri || !jwtSecret) {
+      throw new Error('Missing OAuth configuration');
+    }
+
+    // Exchange code for access token
+    const tokenData = await exchangeCodeForToken(code, clientId, clientSecret, redirectUri);
+
+    // Get user info from Twitch
+    const user = await getTwitchUser(tokenData.access_token, clientId);
+
+    // Create session token
+    const sessionToken = await createSessionToken(user, jwtSecret);
+
+    // Set session cookie and redirect
+    return new Response(null, {
+      status: 302,
+      headers: {
+        'Location': '/player',
+        'Set-Cookie': [
+          `twitch_session=${sessionToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}`,
+          `twitch_oauth_state=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`, // Clear state cookie
+        ].join(', '),
+      },
+    });
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    return redirect('/signin?error=authentication_failed');
+  }
+};

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+export const prerender = false;
+
+export const POST: APIRoute = async ({ redirect }) => {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Location': '/',
+      'Set-Cookie': `twitch_session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    },
+  });
+};
+
+export const GET: APIRoute = async ({ redirect }) => {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Location': '/',
+      'Set-Cookie': `twitch_session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    },
+  });
+};

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from 'astro';
+import { getCurrentUser } from '../../../lib/auth';
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, locals }) => {
+  const { env } = locals.runtime;
+  const jwtSecret = env.JWT_SECRET;
+
+  if (!jwtSecret) {
+    return new Response(JSON.stringify({ error: 'Server configuration error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const user = await getCurrentUser(request, jwtSecret);
+
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'Not authenticated' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ user }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/auth/twitch.ts
+++ b/src/pages/api/auth/twitch.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+export const prerender = false;
+
+export const GET: APIRoute = async ({ locals, redirect }) => {
+  const { env } = locals.runtime;
+
+  const clientId = env.TWITCH_CLIENT_ID;
+  const redirectUri = env.TWITCH_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    return new Response('Missing Twitch OAuth configuration', { status: 500 });
+  }
+
+  // Generate random state for CSRF protection
+  const state = crypto.randomUUID();
+
+  // Store state in cookie for verification
+  const authUrl = new URL('https://id.twitch.tv/oauth2/authorize');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('scope', 'user:read:email');
+  authUrl.searchParams.set('state', state);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Location': authUrl.toString(),
+      'Set-Cookie': `twitch_oauth_state=${state}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=600`
+    }
+  });
+};

--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -1,9 +1,14 @@
 ---
+export const prerender = false;
+
 import '../styles/wos-plus-player.css';
 import WosBaseLayout from '../layouts/WosBaseLayout.astro';
 import Twitch from '../components/Icons/Twitch.astro';
 import Settings from '../components/Icons/Settings.astro';
 import SettingsDialog from '../components/SettingsDialog.astro';
+import UserMenu from '../components/UserMenu.astro';
+
+const user = Astro.locals.user;
 ---
 
 <WosBaseLayout
@@ -86,15 +91,24 @@ import SettingsDialog from '../components/SettingsDialog.astro';
       <iframe id='player-wos-board-iframe' src='' loading='lazy'></iframe>
     </div>
     <div class='player-channel-data-container'>
-      <button
-        id='open-settings-btn'
-        class='settings-button'
-        type='button'
-        aria-label='Open settings'
-        title='Settings'
-      >
-        <Settings size={24} />
-      </button>
+      <div class='player-header-controls'>
+        {user && (
+          <UserMenu
+            username={user.username}
+            displayName={user.display_name}
+            profileImage={user.profile_image_url}
+          />
+        )}
+        <button
+          id='open-settings-btn'
+          class='settings-button'
+          type='button'
+          aria-label='Open settings'
+          title='Settings'
+        >
+          <Settings size={24} />
+        </button>
+      </div>
       <div id='overlay' class='overlay'>
         <div id='level-current' class='level-current'>
           <span id='level-title' class='level-title'>LEVEL</span>
@@ -583,6 +597,17 @@ import SettingsDialog from '../components/SettingsDialog.astro';
   :global(.widget-mode .wrapper) {
     max-width: 100% !important;
     padding: 0 !important;
+  }
+
+  /* Header controls */
+  .player-header-controls {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    z-index: 10;
   }
 
   /* Settings form styles */

--- a/src/pages/signin.astro
+++ b/src/pages/signin.astro
@@ -1,0 +1,220 @@
+---
+export const prerender = false;
+
+import WosBaseLayout from '../layouts/WosBaseLayout.astro';
+import Twitch from '../components/Icons/Twitch.astro';
+
+const url = Astro.url;
+const error = url.searchParams.get('error');
+const redirect = url.searchParams.get('redirect');
+
+const errorMessages: Record<string, string> = {
+  invalid_request: 'Invalid authentication request',
+  invalid_state: 'Invalid authentication state. Please try again.',
+  authentication_failed: 'Authentication failed. Please try again.',
+  config_error: 'Server configuration error. Please contact support.',
+};
+
+const errorMessage = error ? errorMessages[error] || 'An error occurred. Please try again.' : null;
+---
+
+<WosBaseLayout
+  title="Sign In | WoS+ Words on Stream Plus"
+  description="Sign in with your Twitch account to access WoS+ features"
+  keywords="sign in, login, twitch, authentication, wos plus"
+>
+  <div class="signin-page">
+    <div class="signin-container">
+      <div class="signin-card">
+        <div class="logo-section">
+          <span class="brand-name">WoS<span class="plus">+</span></span>
+        </div>
+
+        <h1 class="signin-title">Sign in to continue</h1>
+        <p class="signin-subtitle">
+          Connect your Twitch account to access player and streamer features
+        </p>
+
+        {errorMessage && (
+          <div class="error-banner">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"></circle>
+              <line x1="12" y1="8" x2="12" y2="12"></line>
+              <line x1="12" y1="16" x2="12.01" y2="16"></line>
+            </svg>
+            <span>{errorMessage}</span>
+          </div>
+        )}
+
+        <a href="/api/auth/twitch" class="twitch-signin-btn">
+          <Twitch width={24} height={24} />
+          <span>Sign in with Twitch</span>
+        </a>
+
+        <p class="privacy-notice">
+          By signing in, you agree to share your Twitch username and email with WoS+.
+          We respect your privacy and will never share your information.
+        </p>
+
+        <div class="back-link">
+          <a href="/">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="19" y1="12" x2="5" y2="12"></line>
+              <polyline points="12 19 5 12 12 5"></polyline>
+            </svg>
+            Back to home
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</WosBaseLayout>
+
+<style>
+  .signin-page {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #161625 0%, #2a1a4a 100%);
+    padding: 2rem;
+  }
+
+  .signin-container {
+    width: 100%;
+    max-width: 450px;
+  }
+
+  .signin-card {
+    background: rgba(30, 30, 46, 0.8);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    border-radius: 1.5rem;
+    padding: 3rem 2.5rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(10px);
+  }
+
+  .logo-section {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .brand-name {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .brand-name .plus {
+    color: #8b5cf6;
+    font-weight: 800;
+  }
+
+  .signin-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.95);
+    margin: 0 0 0.75rem 0;
+    text-align: center;
+  }
+
+  .signin-subtitle {
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0 0 2rem 0;
+    text-align: center;
+    line-height: 1.5;
+  }
+
+  .error-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 0.75rem;
+    color: #fca5a5;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+  }
+
+  .error-banner svg {
+    flex-shrink: 0;
+  }
+
+  .twitch-signin-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 1rem 1.5rem;
+    background: #9146ff;
+    color: white;
+    border: none;
+    border-radius: 0.75rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px rgba(145, 70, 255, 0.3);
+  }
+
+  .twitch-signin-btn:hover {
+    background: #7d3cd1;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(145, 70, 255, 0.4);
+  }
+
+  .twitch-signin-btn:active {
+    transform: translateY(0);
+  }
+
+  .privacy-notice {
+    margin: 1.5rem 0 0 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.5);
+    text-align: center;
+    line-height: 1.5;
+  }
+
+  .back-link {
+    margin-top: 2rem;
+    text-align: center;
+  }
+
+  .back-link a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #8b5cf6;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+    transition: color 0.2s ease;
+  }
+
+  .back-link a:hover {
+    color: #a78bfa;
+  }
+
+  @media (max-width: 640px) {
+    .signin-page {
+      padding: 1rem;
+    }
+
+    .signin-card {
+      padding: 2rem 1.5rem;
+    }
+
+    .brand-name {
+      font-size: 2rem;
+    }
+
+    .signin-title {
+      font-size: 1.5rem;
+    }
+  }
+</style>

--- a/src/pages/streamer.astro
+++ b/src/pages/streamer.astro
@@ -1,8 +1,13 @@
 ---
+export const prerender = false;
+
 import '../styles/wos-plus-streamer.css';
 import WosBaseLayout from '../layouts/WosBaseLayout.astro';
 import Twitch from '../components/Icons/Twitch.astro';
 import SettingsDialog from '../components/SettingsDialog.astro';
+import UserMenu from '../components/UserMenu.astro';
+
+const user = Astro.locals.user;
 ---
 
 <WosBaseLayout
@@ -58,6 +63,15 @@ import SettingsDialog from '../components/SettingsDialog.astro';
       <iframe id='streamer-wos-board-iframe' src='' loading='lazy'></iframe>
     </div>
     <div class='streamer-channel-data-container'>
+      <div class='streamer-header-controls'>
+        {user && (
+          <UserMenu
+            username={user.username}
+            displayName={user.display_name}
+            profileImage={user.profile_image_url}
+          />
+        )}
+      </div>
       <div id='overlay' class='overlay'>
         <div id='level-current' class='level-current'>
           <span id='level-title' class='level-title'>LEVEL</span>
@@ -459,6 +473,17 @@ import SettingsDialog from '../components/SettingsDialog.astro';
   :global(.widget-mode .wrapper) {
     max-width: 100% !important;
     padding: 0 !important;
+  }
+
+  /* Header controls */
+  .streamer-header-controls {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    z-index: 10;
   }
 
   /* Settings form styles */


### PR DESCRIPTION
This commit implements comprehensive Twitch authentication to protect the player and streamer views. Users must now sign in with their Twitch account before accessing these features.

Changes:
- Add Twitch OAuth flow with login and callback endpoints
- Implement JWT-based session management with httpOnly cookies
- Create authentication middleware to protect player and streamer routes
- Add sign-in page with Twitch OAuth integration
- Create UserMenu component for user profile display and logout
- Update player and streamer pages with user authentication
- Add comprehensive environment variable documentation
- Update TypeScript definitions for authenticated user in locals

Authentication flow:
1. User visits /player or /streamer
2. Middleware checks for valid session
3. If not authenticated, redirect to /signin
4. User clicks "Sign in with Twitch"
5. OAuth flow exchanges code for token
6. JWT session cookie is created
7. User is redirected back to original page

Security features:
- CSRF protection with state parameter
- HttpOnly, Secure, SameSite cookies
- JWT token verification
- 7-day session expiration

Required environment variables:
- TWITCH_CLIENT_ID
- TWITCH_CLIENT_SECRET
- TWITCH_REDIRECT_URI
- JWT_SECRET