### PR TITLE
Always reconnect live connections on settings save

### DIFF
--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -486,6 +486,9 @@ import MadeBy from "../components/MadeBy.astro";
 
       const channelChanged = newChannel !== twitchChannel;
       twitchChannel = newChannel;
+
+      // Only swap the chat embed when the channel actually changed to avoid an
+      // unnecessary reload of the iframe.
       if (channelChanged) {
         const twitchChatWidget = document.getElementById(
           "player-twitch-chat-widget",
@@ -493,14 +496,22 @@ import MadeBy from "../components/MadeBy.astro";
         if (twitchChatWidget) {
           twitchChatWidget.src = `https://www.twitch.tv/embed/${twitchChannel}/chat?darkpopout&parent=${location.hostname}`;
         }
-        spectator.connectToTwitch(twitchChannel);
       }
 
+      // Only re-point the board iframe when the mirror URL actually changed.
       if (mirrorUrlChanged) {
         loadBoardIframeIfVisible();
-        if (currentMirrorUrl) {
-          spectator.connectToWosGame(currentMirrorUrl);
-        }
+      }
+
+      // Always tear down and re-establish the live connections on save. The
+      // dialog now applies settings in place instead of reloading the page, so
+      // these reconnects are the only thing that picks up the new settings.
+      // connectToTwitch/connectToWosGame each close any previous connection
+      // before opening a new one, so saving reliably reconnects even when the
+      // value itself is unchanged (issue #88).
+      spectator.connectToTwitch(twitchChannel);
+      if (currentMirrorUrl) {
+        spectator.connectToWosGame(currentMirrorUrl);
       }
     });
   };

--- a/src/pages/streamer.astro
+++ b/src/pages/streamer.astro
@@ -367,6 +367,9 @@ import MadeBy from "../components/MadeBy.astro";
 
       const channelChanged = newChannel !== twitchChannel;
       twitchChannel = newChannel;
+
+      // Only swap the chat embed when the channel actually changed to avoid an
+      // unnecessary reload of the iframe.
       if (channelChanged) {
         const twitchChatWidget = document.getElementById(
           "streamer-twitch-chat-widget",
@@ -374,14 +377,22 @@ import MadeBy from "../components/MadeBy.astro";
         if (twitchChatWidget) {
           twitchChatWidget.src = `https://www.twitch.tv/embed/${twitchChannel}/chat?darkpopout&parent=${location.hostname}`;
         }
-        spectator.connectToTwitch(twitchChannel);
       }
 
+      // Only re-point the board iframe when the mirror URL actually changed.
       if (mirrorUrlChanged) {
         loadBoardIframeIfVisible();
-        if (currentMirrorUrl) {
-          spectator.connectToWosGame(currentMirrorUrl);
-        }
+      }
+
+      // Always tear down and re-establish the live connections on save. The
+      // dialog now applies settings in place instead of reloading the page, so
+      // these reconnects are the only thing that picks up the new settings.
+      // connectToTwitch/connectToWosGame each close any previous connection
+      // before opening a new one, so saving reliably reconnects even when the
+      // value itself is unchanged (issue #88).
+      spectator.connectToTwitch(twitchChannel);
+      if (currentMirrorUrl) {
+        spectator.connectToWosGame(currentMirrorUrl);
       }
     });
   };
@@ -461,11 +472,19 @@ import MadeBy from "../components/MadeBy.astro";
       // Try to get the API immediately if it exists
       if ((dialog as any).__api) {
         settingsDialog = (dialog as any).__api;
+        setupDialogCallbacks();
       } else {
         // If not ready yet, wait for the event
-        dialog.addEventListener("dialog-ready", initializeSettingsDialog, {
-          once: true,
-        });
+        dialog.addEventListener(
+          "dialog-ready",
+          (event) => {
+            initializeSettingsDialog(event);
+            setupDialogCallbacks();
+          },
+          {
+            once: true,
+          },
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
Refactored the settings save logic to always tear down and re-establish live connections (Twitch and WoS Game) regardless of whether the channel or mirror URL changed. This ensures new settings are picked up even when values themselves remain unchanged.

## Key Changes
- **Separated iframe updates from connection logic**: Chat and board iframe updates now only occur when their respective URLs actually changed, avoiding unnecessary reloads
- **Moved connection reconnects outside conditional blocks**: `connectToTwitch()` and `connectToWosGame()` now always execute on settings save, ensuring settings changes are applied even when values are unchanged (fixes issue #88)
- **Updated dialog initialization**: Added `setupDialogCallbacks()` call in both the immediate and deferred dialog-ready paths to ensure callbacks are properly registered
- **Applied changes to both pages**: Updated identical logic in both `streamer.astro` and `player.astro`

## Implementation Details
- The reconnection logic leverages the fact that `connectToTwitch()` and `connectToWosGame()` each close any previous connection before opening a new one, making them safe to call unconditionally
- This change was necessary because the settings dialog now applies changes in-place rather than reloading the page, so reconnecting is the only way to pick up new configuration values
- Added clarifying comments explaining the rationale for the new structure