### PR TITLE
Skip sound playback when tab is hidden (issue #86)

### DIFF
--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -197,6 +197,14 @@ export class GameSpectator {
       return;
     }
 
+    // Skip playback while the tab is in the background. Browsers throttle the
+    // setTimeout-based delays in the level-end pipeline for hidden tabs, so
+    // several rounds' worth of sounds would otherwise queue up and fire all at
+    // once when the tab is brought back to the foreground (issue #86).
+    if (typeof document !== 'undefined' && document.hidden) {
+      return;
+    }
+
     const soundFile = this.soundEventTypes.get(eventType);
     const audio = new Audio(soundFile || '/assets/nothing.mp3');
     audio.play().catch((error) => {

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -927,6 +927,21 @@ describe('GameSpectator class', () => {
       const audioInstance = audioMock.mock.instances[audioMock.mock.instances.length - 1];
       expect(audioInstance.play).toHaveBeenCalled();
     });
+
+    it('should not create Audio when the tab is hidden (issue #86)', () => {
+      spectator.isSoundsEnabled = true;
+      const hiddenSpy = vi
+        .spyOn(document, 'hidden', 'get')
+        .mockReturnValue(true);
+
+      try {
+        (spectator as any).playSound('level_clear');
+
+        expect((global as any).Audio).not.toHaveBeenCalled();
+      } finally {
+        hiddenSpy.mockRestore();
+      }
+    });
   });
 
   describe('handleLevelResults sound effects', () => {


### PR DESCRIPTION
## Summary
Prevent audio playback when the browser tab is in the background to avoid sound queuing issues caused by browser throttling of timers in hidden tabs.

## Key Changes
- Added a check in the `playSound()` method to skip audio creation when `document.hidden` is true
- Prevents multiple rounds of sounds from queuing up and firing simultaneously when the tab is brought back to the foreground
- Added comprehensive test coverage to verify the fix works correctly

## Implementation Details
The fix leverages the Page Visibility API (`document.hidden`) to detect when a tab is in the background. When hidden, the method returns early without creating an Audio instance. This prevents the issue where browser throttling of setTimeout-based delays in the level-end pipeline causes sounds to accumulate and play all at once when the tab regains focus.

The implementation includes a type check for `document` to ensure compatibility in non-browser environments.