### PR TITLE
Fix duplicate letter fabrication in hidden letter reveals (issue #85)

### DIFF
--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -175,9 +175,28 @@ export class GameSpectator {
 
     console.log('Current Level Big Word:', this.currentLevelBigWord);
     if (this.currentLevelBigWord === '') {
-      // Then update currentLevelLetters with the hidden letters and remove the fake letters
+      // Remove the fake/decoy letters that were never part of this board.
       this.currentLevelLetters = this.currentLevelLetters.filter(letter => !falseLetters.includes(letter));
-      this.currentLevelLetters.push(...hiddenLetters);
+
+      // Each hidden tile is represented by a '?' placeholder in the board's
+      // letters, so fill those placeholders one-for-one with the revealed
+      // hidden letters rather than blindly appending them.
+      //
+      // Appending caused issue #85: when a reveal carried a letter with no '?'
+      // slot to fill — a repeated/cumulative reveal event, or a hidden letter
+      // whose value was already visible on the board — the extra push
+      // fabricated a duplicate valid letter (the spurious CAUTION 'C' / REALITY
+      // 'L' seen on stream), which in turn polluted the end-of-level missed-word
+      // calculations. Capping the merge to the available '?' slots keeps the
+      // valid-letter multiset in sync with the actual number of tiles and makes
+      // the merge idempotent. Genuine duplicates are still preserved because
+      // each real hidden duplicate has its own '?' slot to fill.
+      const revealed = [...hiddenLetters];
+      this.currentLevelLetters = this.currentLevelLetters.map(letter =>
+        letter === '?' && revealed.length > 0 ? revealed.shift()! : letter
+      );
+
+      // Drop any leftover '?' slots that had no matching revealed letter.
       this.currentLevelLetters = this.currentLevelLetters.filter(letter => letter !== '?');
       console.log('Updated currentLevelLetters:', this.currentLevelLetters);
       document.getElementById('letters')!.innerText = this.currentLevelLetters.join(' ').toUpperCase();

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -1030,6 +1030,42 @@ describe('GameSpectator class', () => {
       expect(spectator.currentLevelLetters).not.toContain('x');
       expect(spectator.currentLevelLetters).not.toContain('?');
     });
+
+    it('should not fabricate a duplicate when a revealed letter has no ? slot (issue #85)', () => {
+      // CAUTION / REALITY regression: the revealed hidden letter is already
+      // present as a visible letter and there is no '?' placeholder for it, so
+      // it must NOT be appended a second time.
+      spectator.currentLevelBigWord = '';
+      spectator.currentLevelLetters = ['c', 'a', 'u', 't', 'i', 'o', 'n'];
+
+      (spectator as any).handleLetterReveal(['c'], []);
+
+      expect(spectator.currentLevelLetters).toEqual(['c', 'a', 'u', 't', 'i', 'o', 'n']);
+    });
+
+    it('should be idempotent across repeated/cumulative reveal events (issue #85)', () => {
+      // The first reveal fills the '?' slot; a second reveal carrying the same
+      // (now slot-less) hidden letter must not add a duplicate.
+      spectator.currentLevelBigWord = '';
+      spectator.currentLevelLetters = ['c', 'a', 'u', 't', 'i', 'o', '?'];
+
+      (spectator as any).handleLetterReveal(['n'], []);
+      expect(spectator.currentLevelLetters).toEqual(['c', 'a', 'u', 't', 'i', 'o', 'n']);
+
+      (spectator as any).handleLetterReveal(['n'], []);
+      expect(spectator.currentLevelLetters).toEqual(['c', 'a', 'u', 't', 'i', 'o', 'n']);
+    });
+
+    it('should preserve a genuine duplicate hidden letter that has its own ? slot', () => {
+      // Boards may legitimately have duplicate valid letters; when the duplicate
+      // is hidden it gets its own '?' slot, so the merge must keep both copies.
+      spectator.currentLevelBigWord = '';
+      spectator.currentLevelLetters = ['t', 'e', 's', '?'];
+
+      (spectator as any).handleLetterReveal(['t'], []);
+
+      expect(spectator.currentLevelLetters).toEqual(['t', 'e', 's', 't']);
+    });
   });
 
   describe('handleCorrectGuess', () => {


### PR DESCRIPTION
## Summary
Fixed a bug where repeated or cumulative hidden letter reveal events would fabricate duplicate valid letters on the game board, causing incorrect missed-word calculations at level end.

## Key Changes
- **Changed letter reveal merge strategy**: Instead of blindly appending revealed hidden letters to the letters list, the implementation now maps revealed letters one-for-one to their corresponding `?` placeholder slots on the board
- **Prevents duplicate fabrication**: The new approach ensures that:
  - Repeated reveal events for the same letter don't create duplicates (idempotent behavior)
  - Hidden letters whose values are already visible on the board aren't added again
  - Genuine duplicate letters (which have their own `?` slots) are still correctly preserved
- **Cleans up remaining placeholders**: Any `?` slots without matching revealed letters are filtered out

## Implementation Details
The fix replaces a simple `push()` operation with a `map()` operation that:
1. Iterates through the current letters list
2. Replaces each `?` placeholder with the next revealed letter (using `shift()` to consume from the revealed array)
3. Leaves non-placeholder letters unchanged
4. Filters out any remaining `?` slots that had no matching revealed letter

This approach keeps the valid-letter multiset in sync with the actual number of tiles on the board and makes the merge operation idempotent, fixing the spurious duplicate letters (e.g., extra 'C' in CAUTION, extra 'L' in REALITY) that were observed during gameplay.

## Tests Added
Three new test cases ensure the fix handles:
- Letters already visible with no `?` slot
- Idempotent behavior across repeated reveal events
- Preservation of genuine duplicate letters with their own slots

https://claude.ai/code/session_01AV6gBfN5YLnA68uWe7yhKt