### PR TITLE
Redesign landing and player views with "Sticker Pop" theme

### DIFF
--- a/src/layouts/WosBaseLayout.astro
+++ b/src/layouts/WosBaseLayout.astro
@@ -14,6 +14,14 @@ const keywords = Astro.props?.keywords ?? Astro.props?.content?.keywords ?? ''
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
 
+    <!-- Fonts: Fredoka (display), Space Grotesk (UI), Share Tech Mono (data) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- Preload -->
     <slot name="preload" />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
-import Logo from "../components/Icons/Logo.astro";
 import WosBaseLayout from "../layouts/WosBaseLayout.astro";
-import Twitch from "../components/Icons/Twitch.astro";
 ---
 
 <WosBaseLayout
@@ -9,45 +7,36 @@ import Twitch from "../components/Icons/Twitch.astro";
   description="Enhance your Words on Stream experience with WoS+. The ultimate tool for players and streamers to elevate their gameplay."
   keywords="words on stream, wos, wos plus, twitch, streaming, game helper, wordsonstream, tool, clarkio"
 >
-  <div class="landing-page">
-    <!-- Header/Navigation -->
-    <header class="header">
-      <div class="header-content">
-        <div class="logo-section">
-          <span class="brand-name" id="brand-name">WoS<span class="plus">+</span></span>
-        </div>
-      </div>
+  <div class="sp-landing">
+    <!-- ===================== Nav ===================== -->
+    <header class="sp-nav">
+      <a href="/" class="sp-brand">WoS<span class="sp-brand-plus">+</span></a>
+      <nav class="sp-nav-links">
+        <a href="#features">Features</a>
+        <a href="#steps">Steps</a>
+        <a href="./player" class="sp-nav-launch">▶ Launch</a>
+      </nav>
     </header>
 
-    <!-- Hero Section -->
-    <section class="hero">
-      <div class="hero-content">
-        <div class="hero-badge">
-          <Twitch width={75} height={75} />
-          <span>Built for Twitch Streamers & Players</span>
-        </div>
-        <h1 class="hero-title">
-          Words on Stream<span class="gradient-text">+</span>
+    <!-- ===================== Hero ===================== -->
+    <section class="sp-hero">
+      <span class="sp-float-tile sp-float-w">W</span>
+      <span class="sp-float-tile sp-float-o">O</span>
+      <span class="sp-float-tile sp-float-s">S</span>
+
+      <div class="sp-hero-content">
+        <span class="sp-hero-badge">🎮 For Twitch players &amp; streamers</span>
+        <h1 class="sp-hero-title">
+          NEVER<br />MISS A<br /><span class="sp-hero-accent">WORD.</span>
         </h1>
-        <p class="hero-subtitle">
-          Enhance your Words on Stream experience with powerful tools for
-          players and additional features for streamers hosting the game on
-          their channel.
+        <p class="sp-hero-sub">
+          WoS+ tracks every correct word on the board, flags the ones chat
+          missed, and keeps your records — all in real time.
         </p>
-        <div class="hero-cta">
+        <div class="sp-hero-cta">
           <div class="launch-menu-container">
-            <button id="launch-menu-trigger" class="btn btn-primary">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <polygon points="5 3 19 12 5 21 5 3"></polygon>
-              </svg>
-              Launch Tool
+            <button id="launch-menu-trigger" class="sp-btn sp-btn-cyan" type="button">
+              ▶ Launch the tool
               <svg
                 class="chevron-icon"
                 width="16"
@@ -62,396 +51,287 @@ import Twitch from "../components/Icons/Twitch.astro";
             </button>
             <div class="launch-menu-dropdown">
               <a href="./player" class="launch-menu-item">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                  <circle cx="12" cy="7" r="4"></circle>
-                </svg>
-                <div>
-                  <div class="launch-menu-title">Player View</div>
-                  <div class="launch-menu-desc">
-                    Track words and improve your game
-                  </div>
-                </div>
+                <div class="launch-menu-title">Player View</div>
+                <div class="launch-menu-desc">Track words and improve your game</div>
               </a>
               <a href="./streamer" class="launch-menu-item">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path d="M23 7l-7 5 7 5V7z"></path>
-                  <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
-                </svg>
-                <div>
-                  <div class="launch-menu-title">Streamer View</div>
-                  <div class="launch-menu-desc">
-                    Enhanced layout for streaming
-                  </div>
-                </div>
+                <div class="launch-menu-title">Streamer View</div>
+                <div class="launch-menu-desc">Enhanced layout for streaming</div>
               </a>
-            <a href="./bot" class="launch-menu-item">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-                </svg>
-                <div>
-                  <div class="launch-menu-title">Chatbot</div>
-                  <div class="launch-menu-desc">
-                    Add the WoS+ Bot to your Twitch channel
-                  </div>
-                </div>
+              <a href="./bot" class="launch-menu-item">
+                <div class="launch-menu-title">Chatbot</div>
+                <div class="launch-menu-desc">Add the WoS+ Bot to your channel</div>
               </a>
             </div>
           </div>
-          <a href="#features" class="btn btn-secondary">
-            Learn More
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <polyline points="6 9 12 15 18 9"></polyline>
-            </svg>
-          </a>
-        </div>
-      </div>
-      <div class="hero-visual">
-        <div class="floating-card card-1">
-          <div class="card-icon">📝</div>
-          <div class="card-text">Track correct words</div>
-        </div>
-        <div class="floating-card card-2">
-          <div class="card-icon">⏱️</div>
-          <div class="card-text">Personal best times</div>
-        </div>
-        <div class="floating-card card-3">
-          <div class="card-icon">🎮</div>
-          <div class="card-text">Live game state</div>
+          <a href="#features" class="sp-btn sp-btn-pink">See how →</a>
         </div>
       </div>
     </section>
 
-    <!-- Features Section -->
-    <section id="features" class="features">
-      <div class="section-header">
-        <h2 class="section-title">Everything you need to level up</h2>
-        <p class="section-subtitle">
-          Powerful features designed for both players and streamers
+    <!-- ===================== Feature blocks ===================== -->
+    <section id="features" class="sp-features">
+      <div class="sp-feature sp-feature-purple">
+        <div class="sp-feature-num">23</div>
+        <h3>words found, tracked live</h3>
+        <p>
+          Every correct word, grouped by length and alphabetized as the level
+          plays out.
         </p>
       </div>
-
-      <div class="features-grid">
-        <div class="feature-card">
-          <div class="feature-icon">🎯</div>
-          <h3 class="feature-title">Real-time Game Tracking</h3>
-          <p class="feature-description">
-            Automatically track current level, letters, hidden letters, and fake
-            letters in real-time as you play.
-          </p>
-        </div>
-
-        <div class="feature-card">
-          <div class="feature-icon">📊</div>
-          <h3 class="feature-title">Word History Log</h3>
-          <p class="feature-description">
-            Keep track of all correct words found, organized by length in
-            alphabetical order. Never lose track of what's been discovered.
-          </p>
-        </div>
-
-        <div class="feature-card">
-          <div class="feature-icon">🏆</div>
-          <h3 class="feature-title">Personal Records</h3>
-          <p class="feature-description">
-            Monitor your personal best levels reached and daily clear records.
-            Challenge yourself to beat your high scores.
-          </p>
-        </div>
-
-        <div class="feature-card">
-          <div class="feature-icon">💬</div>
-          <h3 class="feature-title">Twitch Chat Integration</h3>
-          <p class="feature-description">
-            Connect directly to Twitch chat to track chat participation and
-            coordinate with other players.
-          </p>
-        </div>
-
-        <div class="feature-card">
-          <div class="feature-icon">📺</div>
-          <h3 class="feature-title">Streamer Dashboard</h3>
-          <p class="feature-description">
-            Enhanced view for streamers with a minimal layout, perfect for OBS
-            integration and stream overlays.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- How It Works Section -->
-    <section class="how-it-works">
-      <div class="section-header">
-        <h2 class="section-title">Get started in seconds</h2>
-        <p class="section-subtitle">
-          Three simple steps to enhance your gameplay
+      <div class="sp-feature sp-feature-pink">
+        <div class="sp-feature-num">2</div>
+        <h3>missed words, flagged</h3>
+        <p>
+          See exactly which valid words chat never guessed — the part everyone
+          wishes they knew.
         </p>
       </div>
-
-      <div class="steps">
-        <div class="step">
-          <div class="step-number">1</div>
-          <h3 class="step-title">Get Your Mirror Link</h3>
-          <p class="step-description">
-            Copy the Words on Stream mirror link from your active game session.
-          </p>
-        </div>
-
-        <div class="step-connector"></div>
-
-        <div class="step">
-          <div class="step-number">2</div>
-          <h3 class="step-title">Connect to WoS+</h3>
-          <p class="step-description">
-            Paste the mirror link into WoS+ and enter your Twitch channel name.
-          </p>
-        </div>
-
-        <div class="step-connector"></div>
-
-        <div class="step">
-          <div class="step-number">3</div>
-          <h3 class="step-title">Start Playing!</h3>
-          <p class="step-description">
-            Enjoy real-time tracking, word history, and all the enhanced
-            features.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- CTA Section -->
-    <section class="cta-section">
-      <div class="cta-content">
-        <h2 class="cta-title">Ready to enhance your experience?</h2>
-        <p class="cta-subtitle">
-          Join streamers and players using WoS+ to take their Words on Stream
-          gameplay to the next level.
+      <div class="sp-feature sp-feature-cyan">
+        <div class="sp-feature-num">12</div>
+        <h3>best level &amp; daily records</h3>
+        <p>
+          Personal bests and daily clears tracked automatically, so you always
+          have a number to beat.
         </p>
-        <a href="./streamer" class="btn btn-primary btn-large">
-          Get Started Now
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <line x1="5" y1="12" x2="19" y2="12"></line>
-            <polyline points="12 5 19 12 12 19"></polyline>
-          </svg>
-        </a>
+      </div>
+      <div class="sp-feature sp-feature-yellow">
+        <div class="sp-feature-num">OBS</div>
+        <h3>drops onto your stream</h3>
+        <p>
+          A minimal streamer layout plus a Twitch chatbot — add it as a browser
+          source and go.
+        </p>
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-      <div class="footer-content">
-        <div class="footer-brand">
-          <div class="logo-section">
-            <span class="brand-name small">WoS<span class="plus">+</span></span>
-          </div>
-          <p class="footer-tagline">
-            Enhancing Words on Stream, one word at a time.
-          </p>
+    <!-- ===================== Steps ===================== -->
+    <section id="steps" class="sp-steps">
+      <h2 class="sp-steps-title">3 steps. That's it.</h2>
+      <div class="sp-steps-row">
+        <div class="sp-step sp-step-1">
+          <div class="sp-step-num">1</div>
+          <div class="sp-step-label">Copy mirror link</div>
         </div>
-        <div class="footer-links">
-          <a href="./streamer" class="footer-link">Streamer View</a>
-          <a href="./bot" class="footer-link">Chatbot</a>
-          <a
-            href="https://wos.gg"
-            target="_blank"
-            rel="noopener"
-            class="footer-link">Words on Stream</a
-          >
-          <a
-            href="https://twitch.tv/clarkio"
-            target="_blank"
-            rel="noopener"
-            class="footer-link"
-          >
-            <Twitch /> clarkio
-          </a>
+        <div class="sp-step sp-step-2">
+          <div class="sp-step-num">2</div>
+          <div class="sp-step-label">Connect WoS+</div>
+        </div>
+        <div class="sp-step sp-step-3">
+          <div class="sp-step-num">3</div>
+          <div class="sp-step-label">Play!</div>
         </div>
       </div>
-      <div class="footer-bottom">
-        <p>Made with 💜 by <a href="https://twitch.tv/clarkio">clarkio</a></p>
+    </section>
+
+    <!-- ===================== Footer ===================== -->
+    <footer class="sp-footer">
+      <a href="/" class="sp-footer-brand">WoS<span class="sp-footer-plus">+</span></a>
+      <div class="sp-footer-by">
+        Made with 💜 by
+        <a href="https://twitch.tv/clarkio" target="_blank" rel="noopener">clarkio</a>
       </div>
     </footer>
   </div>
 </WosBaseLayout>
 
 <style>
-  .landing-page {
+  .sp-landing {
     min-height: 100vh;
     overflow-x: hidden;
-    background-color: var(--bg-dark);
+    background: var(--sp-bg);
+    font-family: var(--font-ui);
+    color: var(--sp-ink);
   }
 
-  /* Header */
-  .header {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: rgba(22, 22, 37, 0.8);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  }
-
-  .header-content {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1rem 2rem;
+  /* ===================== Nav ===================== */
+  .sp-nav {
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    align-items: center;
+    padding: 18px 32px;
+    background: var(--sp-cyan);
+    color: var(--sp-cyan-ink);
   }
 
-  .logo-section {
+  .sp-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 24px;
+    color: var(--sp-bg-deep);
+    text-decoration: none;
+  }
+
+  .sp-brand-plus {
+    color: var(--sp-purple);
+  }
+
+  .sp-nav-links {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 24px;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
   }
 
-  .logo {
-    width: 40px;
-    height: 40px;
+  .sp-nav-links a {
+    color: var(--sp-cyan-ink);
+    text-decoration: none;
   }
 
-  .logo.small {
-    width: 32px;
-    height: 32px;
+  .sp-nav-launch {
+    padding: 9px 20px;
+    border-radius: 999px;
+    background: var(--sp-bg-deep);
+    color: #fff !important;
+    box-shadow: 3px 3px 0 var(--sp-cyan-shadow);
+    transition: transform 0.12s ease;
   }
 
-  .brand-name {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.9);
+  .sp-nav-launch:hover {
+    transform: translate(-1px, -1px);
   }
 
-  #brand-name {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  .brand-name.small {
-    font-size: 1.25rem;
-  }
-
-  .brand-name .plus {
-    color: #8b5cf6;
-    font-weight: 800;
-  }
-
-  .nav {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-  }
-
-  /* Hero Section */
-  .hero {
-    max-width: 1200px;
+  /* ===================== Hero ===================== */
+  .sp-hero {
+    position: relative;
+    overflow: hidden;
+    padding: 54px 32px 50px;
+    max-width: 1240px;
     margin: 0 auto;
-    padding: 4rem 2rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 4rem;
-    align-items: center;
-    min-height: calc(100vh - 80px);
   }
 
-  .hero-content {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-  }
-
-  .hero-badge {
+  .sp-float-tile {
+    position: absolute;
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: rgba(139, 92, 246, 0.1);
-    border: 1px solid rgba(139, 92, 246, 0.3);
-    border-radius: 2rem;
-    font-size: 0.875rem;
+    justify-content: center;
+    font-family: var(--font-display);
+    font-weight: 700;
+    box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.35);
+  }
+
+  .sp-float-w {
+    top: 40px;
+    right: 60px;
+    width: 74px;
+    height: 74px;
+    border-radius: 16px;
+    background: var(--sp-yellow);
+    color: var(--sp-bg-deep);
+    font-size: 40px;
+    transform: rotate(-11deg);
+  }
+
+  .sp-float-o {
+    top: 150px;
+    right: 160px;
+    width: 64px;
+    height: 64px;
+    border-radius: 14px;
+    background: var(--sp-pink);
+    color: #fff;
+    font-size: 34px;
+    transform: rotate(9deg);
+  }
+
+  .sp-float-s {
+    top: 96px;
+    right: 300px;
+    width: 58px;
+    height: 58px;
+    border-radius: 13px;
+    background: #fff;
+    color: var(--sp-purple);
+    font-size: 30px;
+    transform: rotate(-5deg);
+    box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .sp-hero-content {
+    position: relative;
+    max-width: 680px;
+  }
+
+  .sp-hero-badge {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: var(--sp-purple);
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 22px;
+    box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .sp-hero-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 92px;
+    line-height: 0.86;
+    letter-spacing: -2px;
+    color: #fff;
+    text-shadow: 5px 5px 0 var(--sp-purple);
+  }
+
+  .sp-hero-accent {
+    color: var(--sp-yellow);
+    text-shadow: 5px 5px 0 var(--sp-bg-deep);
+  }
+
+  .sp-hero-sub {
+    margin: 26px 0 32px;
+    font-size: 19px;
+    line-height: 1.5;
+    color: var(--sp-ink-muted);
+    max-width: 480px;
     font-weight: 500;
-    color: #8b5cf6;
-    width: fit-content;
   }
 
-  .hero-title {
-    font-size: 3.5rem;
-    font-weight: 800;
-    line-height: 1.1;
-    margin: 0;
-    color: rgba(255, 255, 255, 0.95);
-  }
-
-  .gradient-text {
-    background: linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    font-size: 4.5rem;
-    margin-left: 0.25rem;
-    vertical-align: baseline;
-    line-height: 1;
-  }
-
-  .hero-subtitle {
-    font-size: 1.25rem;
-    line-height: 1.6;
-    color: rgba(255, 255, 255, 0.6);
-    margin: 0;
-  }
-
-  .hero-cta {
+  .sp-hero-cta {
     display: flex;
-    gap: 1rem;
+    gap: 14px;
     flex-wrap: wrap;
   }
 
-  /* Launch Menu */
-  .launch-menu-container {
-    position: relative;
-  }
-
-  #launch-menu-trigger {
+  /* ===================== Buttons ===================== */
+  .sp-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 8px;
+    padding: 16px 30px;
+    border-radius: 14px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 18px;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.12s ease;
+  }
+
+  .sp-btn:hover {
+    transform: translate(-1px, -1px);
+  }
+
+  .sp-btn:active {
+    transform: translate(2px, 2px);
+  }
+
+  .sp-btn-cyan {
+    background: var(--sp-cyan);
+    color: var(--sp-cyan-ink);
+    box-shadow: 5px 5px 0 var(--sp-cyan-shadow);
+  }
+
+  .sp-btn-pink {
+    background: var(--sp-pink);
+    color: #fff;
+    box-shadow: 5px 5px 0 var(--sp-pink-shadow);
   }
 
   .chevron-icon {
@@ -462,21 +342,23 @@ import Twitch from "../components/Icons/Twitch.astro";
     transform: rotate(180deg);
   }
 
+  /* ===================== Launch menu dropdown ===================== */
+  .launch-menu-container {
+    position: relative;
+  }
+
   .launch-menu-dropdown {
     position: absolute;
-    top: calc(100% + 0.5rem);
+    top: calc(100% + 12px);
     left: 0;
     min-width: 280px;
-    background: #1e1e2e;
-    border: 1px solid rgba(139, 92, 246, 0.3);
-    border-radius: 0.75rem;
-    box-shadow:
-      0 10px 25px rgba(0, 0, 0, 0.3),
-      0 0 0 1px rgba(139, 92, 246, 0.1);
+    background: var(--sp-bg-deep);
+    border-radius: 16px;
+    box-shadow: 6px 6px 0 var(--sp-purple);
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-0.5rem);
-    transition: all 0.2s ease;
+    transform: translateY(-8px);
+    transition: all 0.18s ease;
     z-index: 100;
     overflow: hidden;
   }
@@ -488,14 +370,11 @@ import Twitch from "../components/Icons/Twitch.astro";
   }
 
   .launch-menu-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem 1.25rem;
+    display: block;
+    padding: 14px 18px;
     text-decoration: none;
-    color: rgba(255, 255, 255, 0.9);
-    transition: all 0.2s ease;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgba(199, 156, 255, 0.12);
+    transition: background 0.15s ease;
   }
 
   .launch-menu-item:last-child {
@@ -503,460 +382,248 @@ import Twitch from "../components/Icons/Twitch.astro";
   }
 
   .launch-menu-item:hover {
-    background: rgba(139, 92, 246, 0.1);
-  }
-
-  .launch-menu-item svg {
-    flex-shrink: 0;
-    margin-top: 0.125rem;
+    background: rgba(124, 58, 237, 0.25);
   }
 
   .launch-menu-title {
+    font-family: var(--font-display);
     font-weight: 600;
-    font-size: 1rem;
-    margin-bottom: 0.25rem;
-    color: rgba(255, 255, 255, 0.95);
+    font-size: 16px;
+    color: #fff;
+    margin-bottom: 2px;
   }
 
   .launch-menu-desc {
-    font-size: 0.875rem;
-    color: rgba(255, 255, 255, 0.5);
+    font-size: 13px;
+    color: var(--sp-ink-dim);
     line-height: 1.3;
   }
 
-  /* Buttons */
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.75rem;
-    border-radius: 0.5rem;
-    font-weight: 600;
-    font-size: 1rem;
-    text-decoration: none;
-    transition: all 0.2s ease;
-    cursor: pointer;
-    border: none;
-  }
-
-  .btn-primary {
-    background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-    color: white;
-    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(139, 92, 246, 0.4);
-  }
-
-  .btn-secondary {
-    background: transparent;
-    color: #8b5cf6;
-    border: 2px solid #8b5cf6;
-  }
-
-  .btn-secondary:hover {
-    background: rgba(139, 92, 246, 0.1);
-  }
-
-  .btn-large {
-    padding: 1.125rem 2.25rem;
-    font-size: 1.125rem;
-  }
-
-  /* Hero Visual */
-  .hero-visual {
-    position: relative;
-    height: 400px;
-  }
-
-  .floating-card {
-    position: absolute;
-    background: #1e1e2e;
-    padding: 1.25rem 1.5rem;
-    border-radius: 1rem;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    animation: float 3s ease-in-out infinite;
-  }
-
-  .card-icon {
-    font-size: 2rem;
-  }
-
-  .card-text {
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  .card-1 {
-    top: 20%;
-    left: 10%;
-    animation-delay: 0s;
-  }
-
-  .card-2 {
-    top: 50%;
-    right: 5%;
-    animation-delay: 1s;
-  }
-
-  .card-3 {
-    bottom: 15%;
-    left: 20%;
-    animation-delay: 2s;
-  }
-
-  @keyframes float {
-    0%,
-    100% {
-      transform: translateY(0px);
-    }
-    50% {
-      transform: translateY(-20px);
-    }
-  }
-
-  /* Features Section */
-  .features {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 6rem 2rem;
-  }
-
-  .section-header {
-    text-align: center;
-    margin-bottom: 4rem;
-  }
-
-  .section-title {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin: 0 0 1rem 0;
-    color: rgba(255, 255, 255, 0.95);
-  }
-
-  .section-subtitle {
-    font-size: 1.125rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin: 0;
-  }
-
-  .features-grid {
+  /* ===================== Feature blocks ===================== */
+  .sp-features {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 2rem;
-  }
-
-  .feature-card {
-    padding: 2rem;
-    background: #1e1e2e;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 1rem;
-    transition: all 0.3s ease;
-  }
-
-  .feature-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
-  }
-
-  .feature-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-  }
-
-  .feature-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin: 0 0 0.75rem 0;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  .feature-description {
-    font-size: 1rem;
-    line-height: 1.6;
-    color: rgba(255, 255, 255, 0.6);
-    margin: 0;
-  }
-
-  /* How It Works Section */
-  .how-it-works {
-    max-width: 1200px;
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 1240px;
     margin: 0 auto;
-    padding: 6rem 2rem;
-    background: linear-gradient(
-      135deg,
-      rgba(139, 92, 246, 0.05) 0%,
-      rgba(236, 72, 153, 0.05) 100%
-    );
-    border-radius: 2rem;
   }
 
-  .steps {
+  .sp-feature {
+    padding: 38px 34px;
+  }
+
+  .sp-feature h3 {
+    margin: 14px 0 6px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 22px;
+  }
+
+  .sp-feature p {
+    margin: 0;
+    font-size: 14.5px;
+    line-height: 1.5;
+  }
+
+  .sp-feature-num {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 64px;
+    line-height: 1;
+  }
+
+  .sp-feature-purple {
+    background: var(--sp-purple);
+    color: #fff;
+  }
+  .sp-feature-purple h3 { color: #fff; }
+  .sp-feature-purple p { color: #e3d4ff; }
+  .sp-feature-purple .sp-feature-num {
+    color: var(--sp-yellow);
+    text-shadow: 3px 3px 0 var(--sp-bg-deep);
+  }
+
+  .sp-feature-pink {
+    background: var(--sp-pink);
+    color: #fff;
+  }
+  .sp-feature-pink h3 { color: #fff; }
+  .sp-feature-pink p { color: #ffe3ee; }
+  .sp-feature-pink .sp-feature-num {
+    color: var(--sp-bg-deep);
+    text-shadow: 3px 3px 0 rgba(255, 255, 255, 0.4);
+  }
+
+  .sp-feature-cyan {
+    background: var(--sp-cyan);
+    color: var(--sp-cyan-ink);
+  }
+  .sp-feature-cyan h3 { color: var(--sp-cyan-ink); }
+  .sp-feature-cyan p { color: #0c3a36; }
+  .sp-feature-cyan .sp-feature-num { color: var(--sp-bg-deep); }
+
+  .sp-feature-yellow {
+    background: var(--sp-yellow);
+    color: var(--sp-bg-deep);
+  }
+  .sp-feature-yellow h3 { color: var(--sp-bg-deep); }
+  .sp-feature-yellow p { color: #5a3e08; }
+  .sp-feature-yellow .sp-feature-num { color: var(--sp-purple); }
+
+  /* ===================== Steps ===================== */
+  .sp-steps {
+    padding: 46px 34px;
+    text-align: center;
+    max-width: 1240px;
+    margin: 0 auto;
+  }
+
+  .sp-steps-title {
+    margin: 0 0 28px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 36px;
+    color: #fff;
+  }
+
+  .sp-steps-row {
     display: flex;
-    align-items: center;
+    gap: 16px;
     justify-content: center;
-    gap: 2rem;
     flex-wrap: wrap;
   }
 
-  .step {
+  .sp-step {
     flex: 1;
-    min-width: 250px;
-    text-align: center;
+    min-width: 200px;
+    padding: 22px;
+    border-radius: 18px;
+    background: #fff;
+    color: var(--sp-bg-deep);
   }
 
-  .step-number {
-    width: 60px;
-    height: 60px;
-    margin: 0 auto 1.5rem;
+  .sp-step-1 { box-shadow: 5px 5px 0 var(--sp-purple); }
+  .sp-step-2 { box-shadow: 5px 5px 0 var(--sp-pink); }
+  .sp-step-3 { box-shadow: 5px 5px 0 var(--sp-yellow); }
+
+  .sp-step-num {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 34px;
+  }
+
+  .sp-step-1 .sp-step-num { color: var(--sp-cyan); }
+  .sp-step-2 .sp-step-num { color: var(--sp-pink); }
+  .sp-step-3 .sp-step-num { color: var(--sp-yellow-shadow); }
+
+  .sp-step-label {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 16px;
+    margin-top: 4px;
+    color: var(--sp-bg-deep);
+  }
+
+  /* ===================== Footer ===================== */
+  .sp-footer {
     display: flex;
     align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-    color: white;
-    font-size: 1.5rem;
-    font-weight: 700;
-    border-radius: 50%;
-  }
-
-  .step-connector {
-    width: 60px;
-    height: 2px;
-    background: linear-gradient(90deg, #8b5cf6 0%, #ec4899 100%);
-    margin-top: -100px;
-  }
-
-  .step-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin: 0 0 0.75rem 0;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  .step-description {
-    font-size: 1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin: 0;
-  }
-
-  /* CTA Section */
-  .cta-section {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 6rem 2rem;
-  }
-
-  .cta-content {
-    text-align: center;
-    padding: 4rem 2rem;
-    background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-    border-radius: 2rem;
-    color: white;
-  }
-
-  .cta-title {
-    color: rgba(255, 255, 255, 0.9);
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin: 0 0 1rem 0;
-  }
-
-  .cta-subtitle {
-    color: rgba(255, 255, 255, 0.9);
-    font-size: 1.125rem;
-    margin: 0 0 2rem 0;
-    opacity: 0.9;
-  }
-
-  .cta-content .btn-primary {
-    background: white;
-    color: #8b5cf6;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  }
-
-  .cta-content .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
-  }
-
-  /* Footer */
-  .footer {
-    background: #0f0f1a;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-  }
-
-  .footer-content {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 3rem 2rem;
-    display: flex;
     justify-content: space-between;
-    align-items: start;
-    gap: 2rem;
+    padding: 26px 34px;
+    background: var(--sp-bg-darkest);
   }
 
-  .footer-brand {
-    flex: 1;
-  }
-
-  .footer-tagline {
-    margin: 1rem 0 0 0;
-    color: rgba(255, 255, 255, 0.5);
-    font-size: 0.875rem;
-  }
-
-  .footer-links {
-    display: flex;
-    gap: 2rem;
-    flex-wrap: wrap;
-  }
-
-  .footer-link {
-    color: rgba(255, 255, 255, 0.6);
+  .sp-footer-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 20px;
+    color: #fff;
     text-decoration: none;
+  }
+
+  .sp-footer-plus {
+    color: var(--sp-cyan);
+  }
+
+  .sp-footer-by {
+    font-family: var(--font-display);
     font-weight: 500;
-    transition: color 0.2s ease;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    font-size: 13px;
+    color: var(--sp-ink-dim);
   }
 
-  .footer-link:hover {
-    color: #8b5cf6;
-  }
-
-  .footer-bottom {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1.5rem 2rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    text-align: center;
-  }
-
-  .footer-bottom p {
-    margin: 0;
-    color: rgba(255, 255, 255, 0.5);
-    font-size: 0.875rem;
-  }
-
-  .footer-bottom a {
-    color: #8b5cf6;
+  .sp-footer-by a {
+    color: var(--sp-cyan);
     text-decoration: none;
     font-weight: 600;
   }
 
-  .footer-bottom a:hover {
-    text-decoration: underline;
-  }
-
-  /* Responsive Design */
-  @media (max-width: 968px) {
-    .hero {
-      grid-template-columns: 1fr;
-      gap: 3rem;
-      padding: 3rem 1.5rem;
+  /* ===================== Responsive ===================== */
+  @media (max-width: 760px) {
+    .sp-hero {
+      padding: 36px 22px 40px;
     }
 
-    .hero-visual {
-      height: 300px;
+    .sp-hero-title {
+      font-size: 60px;
+      letter-spacing: -1px;
     }
 
-    .hero-title {
-      font-size: 2.5rem;
-    }
-
-    .gradient-text {
-      font-size: 3.25rem;
-    }
-
-    .section-title {
-      font-size: 2rem;
-    }
-
-    .cta-title {
-      font-size: 2rem;
-    }
-
-    .step-connector {
+    .sp-float-tile {
       display: none;
     }
 
-    .footer-content {
+    .sp-features {
+      grid-template-columns: 1fr;
+    }
+
+    .sp-nav {
+      padding: 16px 20px;
+    }
+
+    .sp-nav-links {
+      gap: 14px;
+      font-size: 14px;
+    }
+
+    .sp-hero-cta {
       flex-direction: column;
+      align-items: stretch;
     }
 
-    .footer-links {
-      flex-direction: column;
-      gap: 1rem;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .header-content {
-      padding: 1rem 1rem;
-    }
-
-    .hero {
-      padding: 2rem 1rem;
-    }
-
-    .hero-title {
-      font-size: 2rem;
-    }
-
-    .gradient-text {
-      font-size: 2.75rem;
-    }
-
-    .hero-subtitle {
-      font-size: 1rem;
-    }
-
-    .hero-cta {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
+    .sp-btn {
       justify-content: center;
     }
 
-    .features {
-      padding: 3rem 1rem;
+    .launch-menu-container {
+      width: 100%;
     }
 
-    .how-it-works {
-      padding: 3rem 1rem;
+    #launch-menu-trigger {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+
+  @media (max-width: 460px) {
+    .sp-hero-title {
+      font-size: 46px;
     }
 
-    .cta-section {
-      padding: 3rem 1rem;
-    }
-
-    .cta-content {
-      padding: 2rem 1rem;
-    }
-
-    .features-grid {
-      grid-template-columns: 1fr;
+    .sp-nav-links a:not(.sp-nav-launch) {
+      display: none;
     }
   }
 </style>
 
 <script>
-  import initLaunchMenu from '../lib/launch-menu';
+  import initLaunchMenu from "../lib/launch-menu";
 
   const setup = () => {
     try {
       initLaunchMenu();
     } catch (err) {
       // swallow errors during init to avoid breaking page
-      console.error('There was an issue setting things up for this page', err);
+      console.error("There was an issue setting things up for this page", err);
     }
   };
 
@@ -966,6 +633,6 @@ import Twitch from "../components/Icons/Twitch.astro";
   // Initialize on DOMContentLoaded and Astro page load
   // Astro page load event is needed for SPA navigation
   // Any functions in here should be idempotent
-  document.addEventListener('DOMContentLoaded', setup);
-  document.addEventListener('astro:page-load', setup);
+  document.addEventListener("DOMContentLoaded", setup);
+  document.addEventListener("astro:page-load", setup);
 </script>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -30,9 +30,36 @@
   --font-main: 'Inter', sans-serif;
   --font-mono: 'Share Tech Mono', monospace;
   --font-code: 'Fira Code', monospace;
-  
+  --font-display: 'Fredoka', 'Space Grotesk', sans-serif;
+  --font-ui: 'Space Grotesk', system-ui, sans-serif;
+
   /* Spacing */
   --border-radius: 8px;
+
+  /* ==========================================================================
+     "Sticker Pop" palette — bold, game-native theme shared by the landing and
+     player redesigns. Additive: existing variables above are untouched so the
+     streamer/bot views keep their original look.
+     ========================================================================== */
+  --sp-bg: #1a0633;
+  --sp-bg-deep: #160227;
+  --sp-bg-darkest: #0c0118;
+  --sp-purple: #7c3aed;
+  --sp-purple-deep: #3b0a63;
+  --sp-cyan: #25e6d4;
+  --sp-cyan-shadow: #0c8a7d;
+  --sp-cyan-ink: #0c1b1a;
+  --sp-pink: #ff5c93;
+  --sp-pink-shadow: #b3275e;
+  --sp-pink-soft: #ff9ebb;
+  --sp-yellow: #ffce3a;
+  --sp-yellow-shadow: #ffb300;
+  --sp-tile: #ffffff;
+  --sp-tile-text: #3b0a63;
+  --sp-ink: #f3e9ff;
+  --sp-ink-muted: #d9c5f5;
+  --sp-ink-dim: #9a82c4;
+  --sp-chip: #2a1147;
 }
 
 /* Base HTML Elements */

--- a/src/styles/wos-plus-player.css
+++ b/src/styles/wos-plus-player.css
@@ -6,11 +6,14 @@
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 0.5fr 0.5fr;
   grid-template-rows: 0.25fr 1fr 1fr 1fr;
-  gap: 5px;
+  gap: 14px;
+  padding: 14px;
   width: 100vw;
   height: 100vh;
   max-height: 100vh;
   overflow: hidden;
+  background: var(--sp-bg);
+  font-family: var(--font-ui);
 }
 
 .player-wos-board-container {
@@ -647,4 +650,190 @@
     top: 4px;
     left: 4px;
   }
+}
+
+/* ==========================================================================
+   "Sticker Pop" skin
+   --------------------------------------------------------------------------
+   Re-skins the player view to match the committed landing direction: flat
+   color blocks, hard offset shadows, chunky Fredoka type, sticker HUD badges
+   and chip-style word chips. Only visual properties are touched here — the
+   grid layout, sizing logic and every id/class the spectator script drives
+   (#level-value, #correct-words-log, .word-group, .correct-word, …) are left
+   intact. Scoped to player selectors so the streamer/bot views are unaffected.
+   ========================================================================== */
+
+/* --- Board: purple block with cyan offset shadow ------------------------- */
+.player-wos-board-container {
+  background: var(--sp-purple);
+  border-radius: 20px;
+  box-shadow: 6px 6px 0 var(--sp-cyan);
+}
+
+/* --- Chat: dark block with pink offset shadow ---------------------------- */
+.player-twitch-chat-frame {
+  background: var(--sp-bg-deep);
+  border: none;
+  border-radius: 20px;
+  box-shadow: 6px 6px 0 var(--sp-pink);
+}
+
+/* --- Settings button: white sticker -------------------------------------- */
+.settings-button {
+  background: #fff;
+  border: none;
+  border-radius: 12px;
+  color: var(--sp-purple);
+  box-shadow: 3px 3px 0 var(--sp-bg-deep);
+}
+
+.settings-button:hover {
+  background: #fff;
+  border: none;
+  color: var(--sp-purple);
+  transform: translate(-1px, -1px);
+}
+
+/* --- HUD: LEVEL block + record badges as stickers ------------------------ */
+.player-channel-data-container .level-current {
+  background: var(--sp-bg-deep);
+  border: none;
+  border-radius: 15px;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.35);
+  font-family: var(--font-display);
+}
+
+.player-channel-data-container .level-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: #c9a6ff;
+}
+
+.player-channel-data-container .level-value {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: #fff;
+}
+
+.player-channel-data-container .level-record {
+  border: none;
+  border-radius: 13px;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.3);
+  font-family: var(--font-display);
+  font-weight: 700;
+  padding: 0.2rem 0.6rem 0.2rem 0.3rem;
+  gap: 0.4rem;
+}
+
+/* Trophy / personal best — yellow */
+.player-channel-data-container .level-record:nth-child(1) {
+  background: var(--sp-yellow);
+  color: var(--sp-bg-deep);
+}
+
+/* Daily best — pink */
+.player-channel-data-container .level-record:nth-child(2) {
+  background: var(--sp-pink);
+  color: #fff;
+}
+
+/* Daily clears — cyan */
+.player-channel-data-container .level-record:nth-child(3) {
+  background: var(--sp-cyan);
+  color: var(--sp-cyan-ink);
+}
+
+.player-channel-data-container .level-record .icon,
+.player-channel-data-container .level-record-value {
+  color: inherit;
+}
+
+/* --- Word log: dark block with yellow offset shadow ---------------------- */
+.player-correct-words-log {
+  background: var(--sp-bg-deep);
+  border: none;
+  border-radius: 20px;
+  box-shadow: 6px 6px 0 var(--sp-yellow);
+}
+
+.correct-words-header {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: #fff;
+}
+
+.correct-words-header :global(.made-by),
+.correct-words-header .made-by {
+  color: var(--sp-cyan);
+}
+
+/* Length badge — small yellow sticker square */
+.player-bottom-container .word-group {
+  border-bottom: none;
+}
+
+.player-bottom-container .word-group__title {
+  background: var(--sp-yellow);
+  color: var(--sp-bg-deep);
+  border-radius: 9px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  padding: 0.15em 0.35em;
+}
+
+/* Found word — purple chip */
+.player-bottom-container .correct-word {
+  background: var(--sp-chip);
+  color: #e9dcff;
+  border-radius: 9px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0;
+  padding: 0.2rem 0.6rem;
+}
+
+/* Missed word — pink chip */
+.player-bottom-container .correct-word.missing-word {
+  background: var(--sp-pink);
+  border-color: transparent;
+  color: #fff;
+}
+
+/* --- Letters panel: dark block with cyan offset shadow ------------------- */
+.level-data-container {
+  background: var(--sp-bg-deep);
+  border: none;
+  border-radius: 20px;
+  box-shadow: 6px 6px 0 var(--sp-cyan);
+}
+
+.level-data-container .letters-label,
+.level-data-container .hidden-letter-label,
+.level-data-container .fake-letter-label {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--sp-ink-dim);
+}
+
+.level-data-container .letters {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 2px;
+}
+
+.level-data-container .hidden-letter {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: var(--sp-yellow);
+  letter-spacing: 2px;
+}
+
+.level-data-container .fake-letter {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: var(--sp-pink);
+  letter-spacing: 2px;
 }


### PR DESCRIPTION
Implements the committed Claude Design direction (1c → 2a/2b): bold flat color blocks, hard offset shadows, chunky Fredoka type, and sticker-tile motifs, native to the Words on Stream game look.

- WosBaseLayout: load Fredoka / Space Grotesk / Share Tech Mono fonts.
- base.css: add an additive --sp-* palette + display/UI font vars; existing variables left intact so the streamer/bot views are unaffected.
- index.astro: rebuild the landing as the Sticker Pop page (cyan nav, big "NEVER MISS A WORD." hero with floating sticker tiles, 2x2 flat feature blocks, "3 steps" strip, dark footer). The launch-menu dropdown is preserved and restyled.
- wos-plus-player.css: append a Sticker Pop skin re-skinning the board, chat, word log (chip-style words), letters panel, and HUD badges. Only visual properties are overridden — grid layout, responsive rules, and every JS hook the spectator drives are left intact.