### PR TITLE
Fix hidden word resolution to use newest-first with letter-fit validation

### DIFF
--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -1,7 +1,7 @@
 import tmi, { type Client as tmiClient } from '@tmi.js/chat';
 import io from 'socket.io-client';
 
-import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord } from './wos-words';
+import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord } from './wos-words';
 import { saveBoard, fetchBoard, fetchChannelStats } from './db-service';
 import { getMirrorGameId } from './mirror-url';
 
@@ -363,11 +363,13 @@ export class GameSpectator {
   // WoS only masks the word at level 19+, and the masked event tells us just
   // the length (one `?` per letter) and which player guessed. We therefore pick
   // among that player's messages of the same length, preferring real dictionary
-  // words (chat may also contain invalid guesses of the same length), and break
-  // ties oldest-first because WoS validates a player's guesses in the order they
-  // were typed. The chosen message is marked `consumed` so a second correct
-  // guess from the same player can't resolve to the same message. This is what
-  // keeps near-simultaneous and rapid-fire guesses from colliding (issue #96).
+  // words whose letters actually fit within the level's tiles (chat may also
+  // contain invalid guesses of the same length), and break ties newest-first
+  // because the most recent same-length message is the likeliest to be the word
+  // WoS just accepted. The chosen message is marked `consumed` so a second
+  // correct guess from the same player can't resolve to the same message. This
+  // is what keeps near-simultaneous and rapid-fire guesses from colliding
+  // (issue #96).
   private resolveGuessedWord(username: string, length: number): string | null {
     const history = this.twitchChatLog.get(username.toLowerCase());
     if (!history || history.length === 0) return null;
@@ -375,13 +377,16 @@ export class GameSpectator {
     const candidates = history.filter(m => !m.consumed && m.message.length === length);
     if (candidates.length === 0) return null;
 
-    // Prefer dictionary-valid words; fall back to all same-length candidates if
-    // none are recognized (e.g. the dictionary hasn't loaded, or the player used
-    // a word we don't have on file yet).
-    const valid = candidates.filter(m => isWosWord(m.message));
+    // Prefer real dictionary words whose letters also fit within the level's
+    // valid letters (with '?' matching any still-hidden letter). Fall back to
+    // all same-length candidates if none qualify (e.g. the dictionary hasn't
+    // loaded, or the player used a word we don't have on file yet).
+    const valid = candidates.filter(
+      m => isWosWord(m.message) && canFormWord(m.message, this.currentLevelLetters)
+    );
     const pool = valid.length > 0 ? valid : candidates;
 
-    const chosen = pool.reduce((oldest, m) => (m.timestamp < oldest.timestamp ? m : oldest));
+    const chosen = pool.reduce((newest, m) => (m.timestamp > newest.timestamp ? m : newest));
     chosen.consumed = true;
     return chosen.message;
   }

--- a/src/scripts/wos-words.ts
+++ b/src/scripts/wos-words.ts
@@ -15,6 +15,43 @@ export function isWosWord(word: string): boolean {
   return wosDictionarySet.has(word.toLowerCase());
 }
 
+/**
+ * Returns true when `word` can be spelled using `availableLetters`, respecting
+ * letter frequency (each tile can only be used once). A '?' in availableLetters
+ * is treated as a wildcard that matches any single letter, which is how a
+ * level's still-hidden letters (level 19+) appear before they're revealed.
+ *
+ * Used when reconstructing a masked correct-guess from a player's Twitch chat:
+ * a candidate message must not only be a real word but also actually be
+ * spellable from the level's tiles, otherwise it can't be the word WoS accepted.
+ */
+export function canFormWord(word: string, availableLetters: string[]): boolean {
+  if (!word) return false;
+
+  const available: { [key: string]: number } = {};
+  let wildcards = 0;
+  for (const rawLetter of availableLetters) {
+    const letter = rawLetter.toLowerCase();
+    if (letter === '?') {
+      wildcards++;
+    } else {
+      available[letter] = (available[letter] || 0) + 1;
+    }
+  }
+
+  for (const char of word.toLowerCase()) {
+    if (available[char]) {
+      available[char]--;
+    } else if (wildcards > 0) {
+      wildcards--;
+    } else {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export interface Slot {
   letters: string[];
   user?: string | null;

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -14,15 +14,22 @@ vi.mock('@scripts/twitch-chat-worker', () => ({
 }));
 
 // Mock the wos-words module
-vi.mock('@scripts/wos-words', () => ({
-  findAllMissingWords: vi.fn(() => []),
-  findMissingWordsFromBoard: vi.fn(() => []),
-  loadWordsFromDb: vi.fn(),
-  // Default to "unknown word" so hidden-word resolution falls back to its
-  // length/FIFO heuristic. Individual tests override this to exercise the
-  // dictionary-preference path.
-  isWosWord: vi.fn(() => false),
-}));
+vi.mock('@scripts/wos-words', async (importActual) => {
+  const actual = await importActual<typeof import('@scripts/wos-words')>();
+  return {
+    findAllMissingWords: vi.fn(() => []),
+    findMissingWordsFromBoard: vi.fn(() => []),
+    loadWordsFromDb: vi.fn(),
+    // Default to "unknown word" so hidden-word resolution falls back to its
+    // length/recency heuristic. Individual tests override this to exercise the
+    // dictionary-preference path.
+    isWosWord: vi.fn(() => false),
+    // Keep the real letter-fit check: it's a pure function with no dictionary
+    // dependency, so hidden-word resolution genuinely validates that a candidate
+    // fits within the level's letters.
+    canFormWord: actual.canFormWord,
+  };
+});
 
 // Mock the db-service module
 vi.mock('@scripts/db-service', () => ({
@@ -1512,9 +1519,9 @@ describe('GameSpectator class', () => {
       expect(spectator.currentLevelSlots[1].user).toBe('bob');
     });
 
-    it('should resolve two same-length hidden guesses from one player in FIFO order with consumption (issue #96)', () => {
+    it('should resolve two same-length hidden guesses from one player newest-first with consumption (issue #96)', () => {
       // A single player lands two same-length words in quick succession. Each
-      // correct-guess event must consume a distinct chat message (oldest first)
+      // correct-guess event must consume a distinct chat message (newest first)
       // so the second event does not re-resolve to the first word.
       spectator.currentLevelSlots = [
         { letters: [], word: '', hitMax: false, index: 0, length: 5 },
@@ -1526,8 +1533,9 @@ describe('GameSpectator class', () => {
       (spectator as any).updateGameState('alice', ['?', '?', '?', '?', '?'], 0, false);
       (spectator as any).updateGameState('alice', ['?', '?', '?', '?', '?'], 1, false);
 
-      expect(spectator.currentLevelSlots[0].word).toBe('beard');
-      expect(spectator.currentLevelSlots[1].word).toBe('bread');
+      // The newest same-length message ('bread', timestamp 2) resolves first.
+      expect(spectator.currentLevelSlots[0].word).toBe('bread');
+      expect(spectator.currentLevelSlots[1].word).toBe('beard');
     });
 
     it('should prefer a valid dictionary word when disambiguating a hidden guess (issue #96)', () => {
@@ -1536,6 +1544,7 @@ describe('GameSpectator class', () => {
       // the invalid one was typed first.
       vi.mocked(wosWords.isWosWord).mockImplementation((w: string) => w === 'beard');
 
+      spectator.currentLevelLetters = ['b', 'e', 'a', 'r', 'd'];
       spectator.currentLevelSlots = [
         { letters: [], word: '', hitMax: false, index: 0, length: 5 },
       ];
@@ -1545,6 +1554,43 @@ describe('GameSpectator class', () => {
       (spectator as any).updateGameState('alice', ['?', '?', '?', '?', '?'], 0, false);
 
       expect(spectator.currentLevelSlots[0].word).toBe('beard');
+    });
+
+    it('should reject a dictionary word whose letters do not fit the level (newest-first, letter-fit)', () => {
+      // The player's chat history contains two real, same-length words but only
+      // one can actually be spelled from the level's tiles. The other (even
+      // though it is the newest message) must be rejected because its letters
+      // don't fit within the level's valid letters.
+      vi.mocked(wosWords.isWosWord).mockImplementation(
+        (w: string) => w === 'beard' || w === 'ghost'
+      );
+
+      spectator.currentLevelLetters = ['b', 'e', 'a', 'r', 'd', '?'];
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 5 },
+      ];
+      seedChat(spectator, 'alice', 'beard', 1); // fits the level letters
+      seedChat(spectator, 'alice', 'ghost', 2); // real word, but doesn't fit
+
+      (spectator as any).updateGameState('alice', ['?', '?', '?', '?', '?'], 0, false);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('beard');
+    });
+
+    it('should treat a level ? as a wildcard when checking letter-fit', () => {
+      // The guessed word uses a still-hidden letter (shown as ? on level 19+).
+      // The single ? must satisfy the one missing 'y' so the word still fits.
+      vi.mocked(wosWords.isWosWord).mockImplementation((w: string) => w === 'trilby');
+
+      spectator.currentLevelLetters = ['t', 'l', 'r', 'i', 's', 'm', '?', 'b'];
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 6 },
+      ];
+      seedChat(spectator, 'alice', 'trilby', 1);
+
+      (spectator as any).updateGameState('alice', ['?', '?', '?', '?', '?', '?'], 0, false);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('trilby');
     });
 
     it('should set big word when hitMax is true', () => {

--- a/tests/unit/wos-words.test.ts
+++ b/tests/unit/wos-words.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { findMissingWordsFromBoard } from '@scripts/wos-words';
+import { findMissingWordsFromBoard, canFormWord } from '@scripts/wos-words';
 import type { Slot } from '@scripts/wos-words';
 
 /**
@@ -91,6 +91,49 @@ describe('wos-words module', () => {
       const result = findMissingWordsFromBoard(currentSlots, boardSlots);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('canFormWord', () => {
+    it('should return true when the word fits within the available letters', () => {
+      expect(canFormWord('beard', ['b', 'e', 'a', 'r', 'd'])).toBe(true);
+    });
+
+    it('should ignore extra available letters', () => {
+      expect(canFormWord('beard', ['b', 'e', 'a', 'r', 'd', 'x', 'y', 'z'])).toBe(true);
+    });
+
+    it('should return false when a required letter is missing', () => {
+      expect(canFormWord('ghost', ['b', 'e', 'a', 'r', 'd'])).toBe(false);
+    });
+
+    it('should respect letter frequency (duplicate letters need duplicate tiles)', () => {
+      // "letter" needs two t's and two e's.
+      expect(canFormWord('letter', ['l', 'e', 't', 'r'])).toBe(false);
+      expect(canFormWord('letter', ['l', 'e', 'e', 't', 't', 'r'])).toBe(true);
+    });
+
+    it('should treat ? as a wildcard for any single letter', () => {
+      expect(canFormWord('trilby', ['t', 'l', 'r', 'i', 'b', '?'])).toBe(true);
+    });
+
+    it('should consume one wildcard per unmatched letter', () => {
+      // Two missing letters (s, and a second t) need two wildcards.
+      expect(canFormWord('toast', ['o', 'a', '?'])).toBe(false);
+      expect(canFormWord('toast', ['o', 'a', '?', '?', '?'])).toBe(true);
+    });
+
+    it('should be case-insensitive', () => {
+      expect(canFormWord('BEARD', ['B', 'E', 'A', 'R', 'D'])).toBe(true);
+      expect(canFormWord('Beard', ['b', 'e', 'a', 'r', 'd'])).toBe(true);
+    });
+
+    it('should return false for an empty word', () => {
+      expect(canFormWord('', ['a', 'b', 'c'])).toBe(false);
+    });
+
+    it('should return false when there are no available letters', () => {
+      expect(canFormWord('beard', [])).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR fixes the hidden word resolution logic in WoS+ to correctly handle rapid-fire and near-simultaneous guesses from the same player. The resolution strategy now prioritizes the newest same-length message and validates that candidate words can actually be spelled from the level's available letters.

## Key Changes
- **Reversed resolution order**: Changed from oldest-first (FIFO) to newest-first when disambiguating same-length hidden guesses. The most recent message is more likely to be the word WoS just accepted.
- **Added letter-fit validation**: Implemented `canFormWord()` function that checks whether a candidate word can be spelled using the level's available letters, respecting letter frequency and treating `?` as wildcards for still-hidden letters (level 19+).
- **Updated mock strategy**: Modified the `wos-words` mock in tests to preserve the real `canFormWord` implementation since it's a pure function with no dictionary dependency, allowing tests to genuinely validate letter-fit logic.
- **Enhanced test coverage**: Added comprehensive tests for the new `canFormWord` function and two new test cases validating the letter-fit validation behavior in hidden word resolution.

## Implementation Details
- The `canFormWord()` function uses a frequency map to track available letters and wildcards, ensuring each tile can only be used once and properly handling duplicate letters in words.
- The resolution logic now filters candidates through both dictionary validity (`isWosWord`) and letter-fit (`canFormWord`) before selecting the newest message from the remaining pool.
- Comment updates clarify the new "newest-first" strategy and explain why letter-fit validation is necessary for correct word reconstruction.

https://claude.ai/code/session_01NdwE6F876moZModMUXQaFm