### PR TITLE
Validate Twitch channel in settings and show inline errors

### DIFF
--- a/src/components/SettingsDialog.astro
+++ b/src/components/SettingsDialog.astro
@@ -249,18 +249,42 @@ const { id = 'settings-dialog', title = 'Settings' } = Astro.props;
       }
 
       // Run the save callback and close unless it explicitly aborts by
-      // returning false (e.g. validation failed and the dialog should stay
-      // open so the user can fix their input).
-      const trySave = () => {
+      // returning (or resolving to) false — e.g. validation failed and the
+      // dialog should stay open so the user can fix their input. The
+      // callback may be async (e.g. it needs to verify a Twitch channel over
+      // the network), so the save button is disabled for the duration to
+      // prevent duplicate submits.
+      const trySave = async () => {
         const data = getData();
-        if (saveCallback && saveCallback(data) === false) {
+        if (!saveCallback) {
+          close();
           return;
         }
-        close();
+
+        const originalLabel = saveBtn ? saveBtn.textContent : null;
+        if (saveBtn) {
+          saveBtn.disabled = true;
+          saveBtn.textContent = 'Saving...';
+        }
+
+        try {
+          const result = await saveCallback(data);
+          if (result === false) {
+            return;
+          }
+          close();
+        } finally {
+          if (saveBtn) {
+            saveBtn.disabled = false;
+            saveBtn.textContent = originalLabel;
+          }
+        }
       };
 
       if (saveBtn) {
-        saveBtn.addEventListener('click', trySave);
+        saveBtn.addEventListener('click', () => {
+          trySave();
+        });
       }
 
       // Handle Enter key press to trigger save

--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -45,6 +45,9 @@ import MadeBy from "../components/MadeBy.astro";
           >The Twitch channel to connect to. You can paste the full channel URL
           or just the username.</small
         >
+        <small class="form-error" id="twitch-channel-error" hidden
+          >Enter a valid, existing Twitch channel name.</small
+        >
       </div>
       <div class="form-group">
         <label class="toggle-label">
@@ -281,6 +284,10 @@ import MadeBy from "../components/MadeBy.astro";
 <script>
   import { GameSpectator } from "../scripts/wos-plus-main";
   import { normalizeMirrorUrl } from "../scripts/mirror-url";
+  import {
+    isValidTwitchLoginFormat,
+    twitchChannelExists,
+  } from "../scripts/twitch-channel";
 
   const boardContainer = document.getElementById(
     "wos-board",
@@ -304,6 +311,25 @@ import MadeBy from "../components/MadeBy.astro";
   const clearMirrorUrlError = () => {
     mirrorUrlErrorEl()?.setAttribute("hidden", "");
     mirrorUrlInputEl()?.classList.remove("input-invalid");
+  };
+
+  const twitchChannelErrorEl = () =>
+    document.getElementById("twitch-channel-error") as HTMLElement | null;
+  const twitchChannelInputEl = () =>
+    document.getElementById("twitch-channel-input") as HTMLInputElement | null;
+
+  const showTwitchChannelError = (message?: string) => {
+    const errorEl = twitchChannelErrorEl();
+    if (errorEl && message) {
+      errorEl.textContent = message;
+    }
+    errorEl?.removeAttribute("hidden");
+    twitchChannelInputEl()?.classList.add("input-invalid");
+  };
+
+  const clearTwitchChannelError = () => {
+    twitchChannelErrorEl()?.setAttribute("hidden", "");
+    twitchChannelInputEl()?.classList.remove("input-invalid");
   };
 
   const extractTwitchChannel = (input: string): string => {
@@ -433,7 +459,7 @@ import MadeBy from "../components/MadeBy.astro";
     if (!settingsDialog) return;
 
     // Set up save callback
-    settingsDialog.onSave((data: Record<string, any>) => {
+    settingsDialog.onSave(async (data: Record<string, any>) => {
       // Validate the mirror URL before applying anything. Only official WoS
       // mirror links (https://wos.gg/r/<gameId>) are allowed — anything else
       // (other sites, other paths) is rejected so the board iframe can't be
@@ -449,20 +475,40 @@ import MadeBy from "../components/MadeBy.astro";
       }
       clearMirrorUrlError();
 
+      // Validate the Twitch channel. A malformed or nonexistent channel name
+      // otherwise leaves the chat embed stuck on "Connecting to chat" with no
+      // indication of why (issue #103), so reject it here instead.
+      let newChannel = twitchChannel;
+      if (data.twitchChannel) {
+        const channel = extractTwitchChannel(data.twitchChannel);
+        if (!channel || !isValidTwitchLoginFormat(channel)) {
+          showTwitchChannelError("Enter a valid Twitch channel name.");
+          return false;
+        }
+
+        const exists = await twitchChannelExists(channel);
+        if (exists === false) {
+          showTwitchChannelError(
+            `No Twitch channel found named "${channel}".`,
+          );
+          return false;
+        }
+        // `exists === null` means the check couldn't be completed (e.g. the
+        // lookup service is unreachable) — don't block saving on that.
+
+        clearTwitchChannelError();
+        newChannel = channel;
+      } else {
+        clearTwitchChannelError();
+      }
+
       const params = new URLSearchParams(window.location.search);
 
       // Update the settings parameters with the canonical mirror URL
       if (data.mirrorUrl) {
         params.set("mirrorUrl", normalizedMirrorUrl);
       }
-      let newChannel = twitchChannel;
-      if (data.twitchChannel) {
-        const channel = extractTwitchChannel(data.twitchChannel);
-        if (channel) {
-          params.set("twitchChannel", channel);
-          newChannel = channel;
-        }
-      }
+      params.set("twitchChannel", newChannel);
       // Handle chat enabled toggle
       params.set("chat", data.chatEnabled ? "true" : "false");
       // Handle WoS board visibility toggle

--- a/src/pages/streamer.astro
+++ b/src/pages/streamer.astro
@@ -44,6 +44,9 @@ import MadeBy from "../components/MadeBy.astro";
           >The Twitch channel to connect to. You can paste the full channel URL
           or just the username.</small
         >
+        <small class="form-error" id="streamer-twitch-channel-error" hidden
+          >Enter a valid, existing Twitch channel name.</small
+        >
       </div>
       <div class="form-group">
         <label class="toggle-label">
@@ -242,6 +245,10 @@ import MadeBy from "../components/MadeBy.astro";
 <script>
   import { GameSpectator } from "../scripts/wos-plus-main";
   import { normalizeMirrorUrl } from "../scripts/mirror-url";
+  import {
+    isValidTwitchLoginFormat,
+    twitchChannelExists,
+  } from "../scripts/twitch-channel";
 
   const boardContainer = document.getElementById(
     "wos-board",
@@ -267,6 +274,29 @@ import MadeBy from "../components/MadeBy.astro";
   const clearMirrorUrlError = () => {
     mirrorUrlErrorEl()?.setAttribute("hidden", "");
     mirrorUrlInputEl()?.classList.remove("input-invalid");
+  };
+
+  const twitchChannelErrorEl = () =>
+    document.getElementById(
+      "streamer-twitch-channel-error",
+    ) as HTMLElement | null;
+  const twitchChannelInputEl = () =>
+    document.getElementById(
+      "streamer-twitch-channel-input",
+    ) as HTMLInputElement | null;
+
+  const showTwitchChannelError = (message?: string) => {
+    const errorEl = twitchChannelErrorEl();
+    if (errorEl && message) {
+      errorEl.textContent = message;
+    }
+    errorEl?.removeAttribute("hidden");
+    twitchChannelInputEl()?.classList.add("input-invalid");
+  };
+
+  const clearTwitchChannelError = () => {
+    twitchChannelErrorEl()?.setAttribute("hidden", "");
+    twitchChannelInputEl()?.classList.remove("input-invalid");
   };
 
   const extractTwitchChannel = (input: string): string => {
@@ -321,7 +351,7 @@ import MadeBy from "../components/MadeBy.astro";
     if (!settingsDialog) return;
 
     // Set up save callback
-    settingsDialog.onSave((data: Record<string, any>) => {
+    settingsDialog.onSave(async (data: Record<string, any>) => {
       // Validate the mirror URL before applying anything. Only official WoS
       // mirror links (https://wos.gg/r/<gameId>) are allowed — anything else
       // (other sites, other paths) is rejected so the board iframe can't be
@@ -337,19 +367,39 @@ import MadeBy from "../components/MadeBy.astro";
       }
       clearMirrorUrlError();
 
+      // Validate the Twitch channel. A malformed or nonexistent channel name
+      // otherwise leaves the chat embed stuck on "Connecting to chat" with no
+      // indication of why (issue #103), so reject it here instead.
+      let newChannel = twitchChannel;
+      if (data.twitchChannel) {
+        const channel = extractTwitchChannel(data.twitchChannel);
+        if (!channel || !isValidTwitchLoginFormat(channel)) {
+          showTwitchChannelError("Enter a valid Twitch channel name.");
+          return false;
+        }
+
+        const exists = await twitchChannelExists(channel);
+        if (exists === false) {
+          showTwitchChannelError(
+            `No Twitch channel found named "${channel}".`,
+          );
+          return false;
+        }
+        // `exists === null` means the check couldn't be completed (e.g. the
+        // lookup service is unreachable) — don't block saving on that.
+
+        clearTwitchChannelError();
+        newChannel = channel;
+      } else {
+        clearTwitchChannelError();
+      }
+
       const params = new URLSearchParams(window.location.search);
 
       if (data.mirrorUrl) {
         params.set("mirrorUrl", normalizedMirrorUrl);
       }
-      let newChannel = twitchChannel;
-      if (data.twitchChannel) {
-        const channel = extractTwitchChannel(data.twitchChannel);
-        if (channel) {
-          params.set("twitchChannel", channel);
-          newChannel = channel;
-        }
-      }
+      params.set("twitchChannel", newChannel);
       // Handle clear sound toggle
       params.set("clearSound", data.clearSound ? "true" : "false");
 

--- a/src/scripts/twitch-channel.ts
+++ b/src/scripts/twitch-channel.ts
@@ -1,0 +1,86 @@
+/**
+ * Validation for user-entered Twitch channel/login names.
+ *
+ * Twitch usernames are 4-25 characters of letters, numbers, and underscores.
+ * `isValidTwitchLoginFormat` rejects obvious typos/garbage synchronously,
+ * before any network round trip.
+ *
+ * `twitchChannelExists` confirms the login actually belongs to a Twitch
+ * account. It queries Twitch's own public GQL endpoint (gql.twitch.tv) using
+ * the Client-Id Twitch's web client itself uses for unauthenticated, read-only
+ * browser requests — the same technique used by many third-party Twitch
+ * tools (chat overlays, extensions) since Twitch does not expose Helix (the
+ * official API) for anonymous, credential-free lookups.
+ */
+
+const TWITCH_LOGIN_PATTERN = /^[a-zA-Z0-9_]{4,25}$/;
+
+/** True when `login` matches Twitch's username shape (4-25 alphanumeric/underscore chars). */
+export function isValidTwitchLoginFormat(login: string): boolean {
+  return TWITCH_LOGIN_PATTERN.test(login.trim());
+}
+
+const TWITCH_GQL_ENDPOINT = 'https://gql.twitch.tv/gql';
+// Twitch's own public web client id. It identifies unauthenticated requests
+// from twitch.tv's frontend and is safe to use client-side for read-only
+// lookups like this one.
+const TWITCH_PUBLIC_CLIENT_ID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
+
+// Bounds how long a caller (e.g. the settings dialog's Save button) can be
+// stuck waiting on this unofficial endpoint. Without it a hung connection
+// would leave the UI showing "Saving..." indefinitely.
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Checks whether a Twitch account with the given login exists.
+ *
+ * Returns `true`/`false` when Twitch answers definitively, or `null` when the
+ * check couldn't be completed (network error, timeout, unexpected response).
+ * Callers should treat `null` as "unknown" rather than "invalid" so a
+ * transient outage of this unofficial endpoint doesn't block users from
+ * saving their settings.
+ */
+export async function twitchChannelExists(
+  login: string,
+  opts: { signal?: AbortSignal; timeoutMs?: number } = {}
+): Promise<boolean | null> {
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(
+    () => timeoutController.abort(),
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  );
+
+  // Combine the caller's signal (if any) with our own timeout so either one
+  // can abort the request.
+  opts.signal?.addEventListener('abort', () => timeoutController.abort());
+
+  try {
+    const response = await fetch(TWITCH_GQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Client-Id': TWITCH_PUBLIC_CLIENT_ID,
+      },
+      body: JSON.stringify({
+        query: 'query($login: String!) { user(login: $login) { id } }',
+        variables: { login },
+      }),
+      signal: timeoutController.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const json: any = await response.json();
+    if (json?.errors) {
+      return null;
+    }
+
+    return !!json?.data?.user;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/unit/twitch-channel.test.ts
+++ b/tests/unit/twitch-channel.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isValidTwitchLoginFormat,
+  twitchChannelExists,
+} from '@scripts/twitch-channel';
+
+describe('isValidTwitchLoginFormat', () => {
+  it('accepts a typical login', () => {
+    expect(isValidTwitchLoginFormat('clarkio')).toBe(true);
+  });
+
+  it('accepts logins with numbers and underscores', () => {
+    expect(isValidTwitchLoginFormat('some_user_123')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before checking', () => {
+    expect(isValidTwitchLoginFormat('  clarkio  ')).toBe(true);
+  });
+
+  it('rejects logins shorter than 4 characters', () => {
+    expect(isValidTwitchLoginFormat('abc')).toBe(false);
+  });
+
+  it('rejects logins longer than 25 characters', () => {
+    expect(isValidTwitchLoginFormat('a'.repeat(26))).toBe(false);
+  });
+
+  it('rejects empty input', () => {
+    expect(isValidTwitchLoginFormat('')).toBe(false);
+  });
+
+  it('rejects disallowed characters', () => {
+    expect(isValidTwitchLoginFormat('clark.io')).toBe(false);
+    expect(isValidTwitchLoginFormat('clark io')).toBe(false);
+    expect(isValidTwitchLoginFormat('clark@io')).toBe(false);
+    expect(isValidTwitchLoginFormat('twitch.tv/clarkio')).toBe(false);
+  });
+});
+
+describe('twitchChannelExists', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns true when Twitch reports a matching user', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { user: { id: '123' } } }),
+    });
+
+    await expect(twitchChannelExists('clarkio')).resolves.toBe(true);
+  });
+
+  it('returns false when Twitch reports no matching user', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { user: null } }),
+    });
+
+    await expect(twitchChannelExists('nonexistentchannel')).resolves.toBe(
+      false,
+    );
+  });
+
+  it('returns null when the response is not ok', async () => {
+    (global.fetch as any).mockResolvedValue({ ok: false });
+
+    await expect(twitchChannelExists('clarkio')).resolves.toBeNull();
+  });
+
+  it('returns null when the response contains GraphQL errors', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ errors: [{ message: 'boom' }] }),
+    });
+
+    await expect(twitchChannelExists('clarkio')).resolves.toBeNull();
+  });
+
+  it('returns null when the fetch throws (network error/timeout)', async () => {
+    (global.fetch as any).mockRejectedValue(new Error('network down'));
+
+    await expect(twitchChannelExists('clarkio')).resolves.toBeNull();
+  });
+
+  it('resolves to null instead of hanging forever when the request never settles', async () => {
+    (global.fetch as any).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    await expect(
+      twitchChannelExists('clarkio', { timeoutMs: 20 }),
+    ).resolves.toBeNull();
+  });
+
+  it('sends the login as a GraphQL variable, not interpolated into the query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { user: { id: '1' } } }),
+    });
+    global.fetch = fetchMock;
+
+    await twitchChannelExists('clarkio');
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body);
+    expect(body.variables).toEqual({ login: 'clarkio' });
+    expect(body.query).not.toContain('clarkio');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #103.

- Validates the Twitch channel entered in the Player/Streamer settings dialogs before saving: rejects malformed names synchronously (`isValidTwitchLoginFormat`), then confirms the channel actually exists via Twitch's public GQL endpoint (`twitchChannelExists` in `src/scripts/twitch-channel.ts`).
- Twitch's official Helix API requires registered app credentials this project doesn't have, so the check instead uses `gql.twitch.tv` with the public web Client-Id Twitch's own frontend uses for unauthenticated, read-only requests — the same technique other third-party Twitch tools rely on. The lookup has a 5s timeout and fails **open** (doesn't block saving) on network errors/timeouts, so an outage of this unofficial endpoint can't prevent users from saving their settings.
- Adds an inline error message (`.form-error`) under the Twitch Channel field in both `player.astro` and `streamer.astro`, shown when the name is malformed or doesn't exist, so users no longer see a silently-stuck "Connecting to Chat" with no explanation.
- `SettingsDialog`'s save callback can now be `async` (needed for the network check): the Save button disables and shows "Saving..." while a save is pending, and the dialog only closes if the callback doesn't resolve to `false`.

## Test plan

- [x] `npx vitest run` — all existing tests pass, plus new unit tests in `tests/unit/twitch-channel.test.ts` covering format validation, existence checks (true/false/null), GraphQL-variable-based query (not string interpolation), and the timeout/fail-open path.
- [x] `npx astro check` — no type errors.
- [x] Manually drove the Player settings dialog with Playwright: a real channel (`clarkio`) saves and closes the dialog; a malformed channel name shows the inline error and keeps the dialog open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BxmH8q6hsDXYZazt7fhuco)_