### PR TITLE
Fix landing page dropdown menu being clipped

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -196,7 +196,6 @@ import WosBaseLayout from "../layouts/WosBaseLayout.astro";
   /* ===================== Hero ===================== */
   .sp-hero {
     position: relative;
-    overflow: hidden;
     padding: 54px 32px 50px;
     max-width: 1240px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- The "Launch the tool" dropdown menu (Player View / Streamer View / Chatbot) on the landing page hero was almost entirely clipped by the hero section's `overflow: hidden`, leaving only a sliver visible before the next section.
- Removed `overflow: hidden` from `.sp-hero` — it's now redundant since `.sp-landing` already sets `overflow-x: hidden` at the page level to contain the floating letter tiles, and removing it lets the absolutely-positioned dropdown render fully above the page content (its `z-index: 100` already handles stacking).

## Test plan
- [x] Ran `astro dev`, opened the landing page in a headless browser, clicked "Launch the tool", and confirmed all three menu items (Player View, Streamer View, Chatbot) are fully visible and rendered above the features section.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHmyGfVCV1Un6npsED7Q7P)_