### PR TITLE
Hide pay-walled daily stats badges for chatbot-disabled channels (#79)

### DIFF
--- a/src/pages/api/channel-stats/[channel].ts
+++ b/src/pages/api/channel-stats/[channel].ts
@@ -58,12 +58,13 @@ export const GET: APIRoute = async ({ params }) => {
         .single(),
       // The chatbot is the source of truth for daily stats and only writes them
       // for channels that have it enabled. A channel counts as chatbot-enabled
-      // when its Twitch username appears in the `users` table's
-      // `twitch_usernames` list (issue #79).
+      // when its Twitch username appears in the `users` table (issue #79).
+      // Twitch login names are canonically lowercase, matching the already
+      // lowercased `cleanChannel`, so an equality match is sufficient.
       supabase
         .from('users')
-        .select('twitch_usernames')
-        .contains('twitch_usernames', [cleanChannel])
+        .select('twitch_username')
+        .eq('twitch_username', cleanChannel)
         .limit(1),
     ]);
 

--- a/src/pages/api/channel-stats/[channel].ts
+++ b/src/pages/api/channel-stats/[channel].ts
@@ -44,7 +44,7 @@ export const GET: APIRoute = async ({ params }) => {
 
     const todayUtc = new Date().toISOString().slice(0, 10);
 
-    const [allTimeResult, dailyResult] = await Promise.all([
+    const [allTimeResult, dailyResult, userResult] = await Promise.all([
       supabase
         .from('wos_channel_all_time_records')
         .select('all_time_highest_level_reached')
@@ -56,16 +56,30 @@ export const GET: APIRoute = async ({ params }) => {
         .eq('channel', cleanChannel)
         .eq('stat_date_utc', todayUtc)
         .single(),
+      // The chatbot is the source of truth for daily stats and only writes them
+      // for channels that have it enabled. A channel counts as chatbot-enabled
+      // when its Twitch username appears in the `users` table's
+      // `twitch_usernames` list (issue #79).
+      supabase
+        .from('users')
+        .select('twitch_usernames')
+        .contains('twitch_usernames', [cleanChannel])
+        .limit(1),
     ]);
 
     const allTimePersonalBest = allTimeResult.data?.all_time_highest_level_reached ?? 0;
     const dailyBest = dailyResult.data?.highest_level_reached ?? 0;
     const dailyClears = dailyResult.data?.board_clears ?? 0;
+    // Fail closed: if the lookup errors we treat the channel as not enabled so
+    // empty daily badges stay hidden rather than showing blank values.
+    const chatbotEnabled =
+      !userResult.error && Array.isArray(userResult.data) && userResult.data.length > 0;
 
     return new Response(JSON.stringify({
       allTimePersonalBest,
       dailyBest,
       dailyClears,
+      chatbotEnabled,
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });

--- a/src/pages/player.astro
+++ b/src/pages/player.astro
@@ -121,7 +121,7 @@ import ThemeControl from "../components/ThemeControl.astro";
           <span id="level-value" class="level-value"></span>
         </div>
         <div id="level-record-container" class="level-record-container">
-          <div class="level-record">
+          <div id="pb-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -143,7 +143,7 @@ import ThemeControl from "../components/ThemeControl.astro";
             </span>
             <span id="pb-value" class="level-record-value"></span>
           </div>
-          <div class="level-record">
+          <div id="daily-pb-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -163,7 +163,7 @@ import ThemeControl from "../components/ThemeControl.astro";
             </span>
             <span id="daily-pb-value" class="level-record-value"></span>
           </div>
-          <div class="level-record">
+          <div id="daily-clear-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/streamer.astro
+++ b/src/pages/streamer.astro
@@ -92,7 +92,7 @@ import ThemeControl from "../components/ThemeControl.astro";
           <span id="level-value" class="level-value"></span>
         </div>
         <div id="level-record-container" class="level-record-container">
-          <div class="level-record">
+          <div id="pb-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -114,7 +114,7 @@ import ThemeControl from "../components/ThemeControl.astro";
             </span>
             <span id="pb-value" class="level-record-value"></span>
           </div>
-          <div class="level-record">
+          <div id="daily-pb-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -134,7 +134,7 @@ import ThemeControl from "../components/ThemeControl.astro";
             </span>
             <span id="daily-pb-value" class="level-record-value"></span>
           </div>
-          <div class="level-record">
+          <div id="daily-clear-record" class="level-record">
             <span class="icon">
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -2,9 +2,13 @@ export interface ChannelStats {
   allTimePersonalBest: number;
   dailyBest: number;
   dailyClears: number;
+  // Whether the channel has the chatbot enabled (its Twitch username is in the
+  // `users` table). Only chatbot-enabled channels get daily stats, so the UI
+  // uses this to hide the daily best/clears components otherwise (issue #79).
+  chatbotEnabled: boolean;
 }
 
-const defaultStats: ChannelStats = { allTimePersonalBest: 0, dailyBest: 0, dailyClears: 0 };
+const defaultStats: ChannelStats = { allTimePersonalBest: 0, dailyBest: 0, dailyClears: 0, chatbotEnabled: false };
 
 export async function fetchChannelStats(channel: string): Promise<ChannelStats> {
   if (typeof channel !== 'string' || channel.length === 0) {
@@ -38,6 +42,7 @@ export async function fetchChannelStats(channel: string): Promise<ChannelStats> 
       allTimePersonalBest: data.allTimePersonalBest ?? 0,
       dailyBest: data.dailyBest ?? 0,
       dailyClears: data.dailyClears ?? 0,
+      chatbotEnabled: data.chatbotEnabled ?? false,
     };
   } catch (error) {
     console.error('Error fetching channel stats:', error);

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -59,6 +59,11 @@ export class GameSpectator {
   personalBest: number = 0;
   dailyBest: number = 0;
   dailyClears: number = 0;
+  // Whether the connected channel has the chatbot enabled. Daily best/clears are
+  // only tracked by the chatbot, so we hide those badges for channels without it
+  // (issue #79). The all-time best always shows since it comes from the WoS game
+  // instance over the websocket.
+  chatbotEnabled: boolean = false;
   currentLevelBigWord: string = '';
   currentLevelCorrectWords: string[] = [];
   wosEventQueue: any[] = [];
@@ -95,6 +100,7 @@ export class GameSpectator {
     this.personalBest = stats.allTimePersonalBest;
     this.dailyBest = stats.dailyBest;
     this.dailyClears = stats.dailyClears;
+    this.chatbotEnabled = stats.chatbotEnabled;
     this.updateStatsDisplay();
   }
 
@@ -106,6 +112,7 @@ export class GameSpectator {
     this.personalBest = Math.max(this.personalBest, stats.allTimePersonalBest);
     this.dailyBest = Math.max(this.dailyBest, stats.dailyBest);
     this.dailyClears = Math.max(this.dailyClears, stats.dailyClears);
+    this.chatbotEnabled = stats.chatbotEnabled;
     this.updateStatsDisplay();
   }
 
@@ -122,7 +129,30 @@ export class GameSpectator {
     if (clearElement) {
       clearElement.innerText = `${this.dailyClears}`;
     }
+    this.updateStatsVisibility();
     this.fitHud();
+  }
+
+  /**
+   * Shows or hides the daily best / daily clears badges based on whether the
+   * connected channel has the chatbot enabled. Those two stats are only tracked
+   * by the chatbot, so on channels without it they would otherwise render as
+   * empty badges taking up space (issue #79). The all-time best badge is always
+   * left visible since it comes from the WoS game instance over the websocket.
+   */
+  private updateStatsVisibility() {
+    const dailyRecord =
+      document.getElementById('daily-pb-record') ||
+      document.getElementById('daily-pb-value')?.closest('.level-record');
+    const clearRecord =
+      document.getElementById('daily-clear-record') ||
+      document.getElementById('daily-clear-value')?.closest('.level-record');
+
+    for (const record of [dailyRecord, clearRecord]) {
+      if (record instanceof HTMLElement) {
+        record.style.display = this.chatbotEnabled ? '' : 'none';
+      }
+    }
   }
 
   /**

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -35,7 +35,7 @@ vi.mock('@scripts/wos-words', async (importActual) => {
 vi.mock('@scripts/db-service', () => ({
   saveBoard: vi.fn(),
   fetchBoard: vi.fn(),
-  fetchChannelStats: vi.fn().mockResolvedValue({ allTimePersonalBest: 0, dailyBest: 0, dailyClears: 0 }),
+  fetchChannelStats: vi.fn().mockResolvedValue({ allTimePersonalBest: 0, dailyBest: 0, dailyClears: 0, chatbotEnabled: false }),
 }));
 
 // Mock socket.io-client
@@ -63,6 +63,9 @@ vi.mock('@tmi.js/chat', () => ({
 // programmatically (see buildTestDom) rather than assigning an HTML string to
 // document.body.innerHTML.
 const TEST_DOM_IDS = [
+  'pb-record',
+  'daily-pb-record',
+  'daily-clear-record',
   'pb-value',
   'daily-pb-value',
   'daily-clear-value',
@@ -207,6 +210,7 @@ describe('GameSpectator class', () => {
         allTimePersonalBest: 15,
         dailyBest: 10,
         dailyClears: 3,
+        chatbotEnabled: true,
       });
 
       await (spectator as any).loadChannelRecords('testchannel');
@@ -222,6 +226,7 @@ describe('GameSpectator class', () => {
         allTimePersonalBest: 0,
         dailyBest: 0,
         dailyClears: 0,
+        chatbotEnabled: false,
       });
 
       await (spectator as any).loadChannelRecords('newchannel');
@@ -236,6 +241,7 @@ describe('GameSpectator class', () => {
         allTimePersonalBest: 20,
         dailyBest: 15,
         dailyClears: 5,
+        chatbotEnabled: true,
       });
 
       await (spectator as any).loadChannelRecords('testchannel');
@@ -243,6 +249,43 @@ describe('GameSpectator class', () => {
       expect(document.getElementById('pb-value')!.innerText).toBe('20');
       expect(document.getElementById('daily-pb-value')!.innerText).toBe('15');
       expect(document.getElementById('daily-clear-value')!.innerText).toBe('5');
+    });
+
+    it('should hide the daily best and daily clears badges when the chatbot is not enabled', async () => {
+      vi.mocked(fetchChannelStats).mockResolvedValueOnce({
+        allTimePersonalBest: 20,
+        dailyBest: 0,
+        dailyClears: 0,
+        chatbotEnabled: false,
+      });
+
+      await (spectator as any).loadChannelRecords('nochatbot');
+
+      expect(spectator.chatbotEnabled).toBe(false);
+      // All-time best is always shown; daily best/clears are hidden (issue #79).
+      expect(document.getElementById('pb-record')!.style.display).toBe('');
+      expect(document.getElementById('daily-pb-record')!.style.display).toBe('none');
+      expect(document.getElementById('daily-clear-record')!.style.display).toBe('none');
+    });
+
+    it('should show the daily best and daily clears badges when the chatbot is enabled', async () => {
+      // Start hidden to prove the badges are re-shown for a chatbot-enabled channel.
+      document.getElementById('daily-pb-record')!.style.display = 'none';
+      document.getElementById('daily-clear-record')!.style.display = 'none';
+
+      vi.mocked(fetchChannelStats).mockResolvedValueOnce({
+        allTimePersonalBest: 20,
+        dailyBest: 15,
+        dailyClears: 5,
+        chatbotEnabled: true,
+      });
+
+      await (spectator as any).loadChannelRecords('haschatbot');
+
+      expect(spectator.chatbotEnabled).toBe(true);
+      expect(document.getElementById('pb-record')!.style.display).toBe('');
+      expect(document.getElementById('daily-pb-record')!.style.display).toBe('');
+      expect(document.getElementById('daily-clear-record')!.style.display).toBe('');
     });
   });
 
@@ -659,6 +702,7 @@ describe('GameSpectator class', () => {
         allTimePersonalBest: 10,
         dailyBest: 5,
         dailyClears: 2,
+        chatbotEnabled: true,
       });
 
       spectator.connectToTwitch('testchannel');


### PR DESCRIPTION
## Summary

Closes #79.

The chatbot is the source of truth for a channel's **daily best level** and **daily clears**, and it only writes those stats for channels that have it enabled. On channels without the chatbot, those two badges rendered empty and took up unnecessary space in the HUD.

This change detects whether a channel is chatbot-enabled and hides the daily best / daily clears badges when it isn't. The **all-time best** badge is always left visible, since it comes from the WoS game instance over the websocket rather than the chatbot.

## How it works

A channel counts as chatbot-enabled when its Twitch username appears in the `users` table. The table stores a single `twitch_username` (`text`) column, matched with an equality check against the lowercased channel name (Twitch login names are canonically lowercase, consistent with how the existing stats tables are queried in the same file).

- **`src/pages/api/channel-stats/[channel].ts`** — adds a parallel lookup against the `users` table and returns a new `chatbotEnabled` boolean alongside the existing stats. The lookup fails closed: if it errors, the channel is treated as not enabled so empty badges stay hidden rather than showing blank values.
- **`src/scripts/db-service.ts`** — `ChannelStats` now carries `chatbotEnabled` (defaulting to `false`), surfaced from the API response.
- **`src/scripts/wos-plus-main.ts`** — `GameSpectator` tracks `chatbotEnabled` and toggles the daily badges' visibility whenever stats are (re)loaded, via a new `updateStatsVisibility()` helper.
- **`src/pages/player.astro` / `src/pages/streamer.astro`** — the three record badges get stable wrapper IDs (`pb-record`, `daily-pb-record`, `daily-clear-record`) so the daily two can be toggled in both views.

## Testing

- Added unit tests covering that the daily badges are hidden when `chatbotEnabled` is `false` and re-shown when `true`, and updated existing `ChannelStats` mocks.
- `pnpm vitest run` — all tests pass (226 passed, 28 todo).
- `pnpm build` — succeeds.

https://claude.ai/code/session_01VxeueeZfrqQdD21971xJrM