### PR TITLE
Prevent missed words from being reported twice at level end

### DIFF
--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -478,7 +478,24 @@ export class GameSpectator {
     }
 
     if (missingWords.length > 0) {
+      // Guard against double-reporting. When a run ends on a failed level the
+      // WoS server emits both a "Level Results" (type 4) and a "Game Ended"
+      // (type 5) event, and both handlers call logMissingWords. The two runs
+      // can even resolve the missing set through different paths (board-based
+      // vs the dictionary fallback), so rather than trusting the detectors,
+      // skip anything already displayed — whether guessed or previously
+      // reported as missed (entries carry a trailing '*' marker). This check
+      // is synchronous with the append below, so concurrent invocations of
+      // logMissingWords can't both pass it for the same word.
+      const displayedWords = new Set(
+        this.currentLevelCorrectWords.map(word => word.replace('*', '').toLowerCase())
+      );
       missingWords.forEach(word => {
+        const key = word.toLowerCase();
+        if (displayedWords.has(key)) {
+          return;
+        }
+        displayedWords.add(key);
         this.updateCorrectWordsDisplayed(word + "*");
       });
     }

--- a/src/scripts/wos-words.ts
+++ b/src/scripts/wos-words.ts
@@ -152,6 +152,9 @@ export function findMissingWordsFromBoard(currentSlots: Slot[], boardSlots: Slot
       const currentSlot = currentSlots[index];
       if (currentSlot && !currentSlot.user) {
         missingWords.push(word);
+        // Track it as seen so duplicate slot entries in stored board data
+        // can't produce the same missed word twice.
+        guessedWords.add(word.toLowerCase());
       }
     }
   });
@@ -167,8 +170,11 @@ export function findMissingWordsFromBoard(currentSlots: Slot[], boardSlots: Slot
  * @returns Array of words from dictionaryWords that are not in knownWords
  */
 function findMissingWordsFromList(knownWords: string[], dictionaryWords: string[]): string[] {
-  // Create a Set of knownWords for efficient lookup
-  const knownWordsSet = new Set(knownWords.map(word => word.toLowerCase()));
+  // Create a Set of knownWords for efficient lookup. Known words may carry the
+  // missed-word display marker ('word*') when an earlier logMissingWords pass
+  // already reported them — strip it so those entries still count as known and
+  // don't get re-reported as missing a second time.
+  const knownWordsSet = new Set(knownWords.map(word => word.replace('*', '').toLowerCase()));
 
   // Filter dictionaryWords to find words not in knownWordsSet
   return dictionaryWords.filter(word => !knownWordsSet.has(word.toLowerCase()));

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -1283,6 +1283,72 @@ describe('GameSpectator class', () => {
         expect.arrayContaining(['test*', 'word*', 'words*', 'testing*'])
       );
     });
+
+    it('should not report the same missed word twice across two runs (VARIATE/VERT regression)', async () => {
+      // When a run ends on a failed level WoS emits both a "Level Results"
+      // and a "Game Ended" event, so logMissingWords executes twice. On the
+      // VARIATE board the first run used board-based detection (vert, atria,
+      // vitae) while the second fell back to the dictionary and re-derived
+      // only vert — which then showed up starred twice on the overlay.
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      const mockBoard = {
+        id: 'VARIATE',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [
+          { letters: ['v', 'e', 'r', 't'], word: 'vert', user: 'user1', hitMax: false, index: 0, length: 4 },
+        ],
+      };
+      // First run finds the board; the second run's fetch fails transiently.
+      fetchBoardMock.mockResolvedValueOnce(mockBoard).mockResolvedValueOnce(null);
+
+      vi.mocked(wosWords.findMissingWordsFromBoard).mockReturnValueOnce(['vert', 'atria', 'vitae']);
+      vi.mocked(wosWords.findAllMissingWords).mockReturnValueOnce(['vert']);
+
+      spectator.currentLevelBigWord = 'V A R I A T E';
+      spectator.currentLevelCorrectWords = ['aria', 'avert'];
+      spectator.currentLevelSlots = [
+        { letters: ['.', '.', '.', '.'], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+
+      await (spectator as any).logMissingWords();
+      await (spectator as any).logMissingWords();
+
+      const starred = spectator.currentLevelCorrectWords.filter(w => w.endsWith('*'));
+      expect(starred.sort()).toEqual(['atria*', 'vert*', 'vitae*']);
+    });
+
+    it('should not add a starred entry for a word already displayed as guessed', async () => {
+      const dbService = await import('@scripts/db-service');
+      vi.mocked(dbService.fetchBoard).mockResolvedValueOnce(null);
+      vi.mocked(wosWords.findAllMissingWords).mockReturnValueOnce(['vert', 'atria']);
+
+      spectator.currentLevelBigWord = 'V A R I A T E';
+      spectator.currentLevelCorrectWords = ['vert'];
+      spectator.currentLevelSlots = [
+        { letters: ['.', '.', '.', '.'], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(spectator.currentLevelCorrectWords.sort()).toEqual(['atria*', 'vert']);
+    });
+
+    it('should display a missed word once when a detector returns it twice', async () => {
+      const dbService = await import('@scripts/db-service');
+      vi.mocked(dbService.fetchBoard).mockResolvedValueOnce(null);
+      vi.mocked(wosWords.findAllMissingWords).mockReturnValueOnce(['vert', 'VERT']);
+
+      spectator.currentLevelBigWord = 'V A R I A T E';
+      spectator.currentLevelCorrectWords = [];
+      spectator.currentLevelSlots = [
+        { letters: ['.', '.', '.', '.'], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(spectator.currentLevelCorrectWords).toEqual(['vert*']);
+    });
   });
 
   describe('worker routing (startEventProcessors)', () => {

--- a/tests/unit/wos-words.test.ts
+++ b/tests/unit/wos-words.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { findMissingWordsFromBoard, canFormWord } from '@scripts/wos-words';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { findMissingWordsFromBoard, findAllMissingWords, loadWordsFromDb, canFormWord } from '@scripts/wos-words';
 import type { Slot } from '@scripts/wos-words';
 
 /**
@@ -22,9 +22,36 @@ describe('wos-words module', () => {
   });
 
   describe('findAllMissingWords', () => {
-    it.todo('should identify missing words from a level');
-    it.todo('should respect minimum word length');
-    it.todo('should handle known letters correctly');
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    // Loads the module-level dictionary through the same path production uses.
+    const loadDictionary = async (words: string[]) => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => words,
+      }));
+      await loadWordsFromDb();
+    };
+
+    it('should identify missing words from a level', async () => {
+      await loadDictionary(['aria', 'vert', 'atria']);
+
+      const result = findAllMissingWords(['aria'], 'variate', 4);
+
+      expect(result.sort()).toEqual(['atria', 'vert']);
+    });
+
+    it('should treat *-marked known words as already reported (VARIATE/VERT regression)', async () => {
+      await loadDictionary(['aria', 'vert', 'atria']);
+
+      // 'vert*' and 'atria*' were appended by an earlier missed-word pass;
+      // a re-run must not surface them as missing again.
+      const result = findAllMissingWords(['aria', 'vert*', 'atria*'], 'variate', 4);
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe('findMissingWordsFromBoard', () => {
@@ -76,6 +103,22 @@ describe('wos-words module', () => {
       const result = findMissingWordsFromBoard(currentSlots, boardSlots);
 
       expect(result).toEqual(['word']);
+    });
+
+    it('should report a word only once when board data contains duplicate slots', () => {
+      const currentSlots: Slot[] = [
+        { letters: ['v', 'e', 'r', 't'], word: '', user: undefined, hitMax: false },
+        { letters: ['v', 'e', 'r', 't'], word: '', user: undefined, hitMax: false },
+      ];
+
+      const boardSlots: Slot[] = [
+        { letters: ['v', 'e', 'r', 't'], word: 'vert', user: 'user1', hitMax: false },
+        { letters: ['v', 'e', 'r', 't'], word: 'vert', user: 'user2', hitMax: false },
+      ];
+
+      const result = findMissingWordsFromBoard(currentSlots, boardSlots);
+
+      expect(result).toEqual(['vert']);
     });
 
     it('should skip empty words in board data', () => {


### PR DESCRIPTION
## Problem

On the VARIATE board, the overlay showed **VERT\*** as a missed word twice, while ATRIA\* and VITAE\* appeared once.

## Root cause

When a run ends on a failed level, the WoS server emits **both** a "Level Results" (type 4) and a "Game Ended" (type 5) event, and both handlers call `logMissingWords()`. Each run appended its findings to the correct-words display with no duplicate check.

The two runs don't necessarily agree, because `logMissingWords` resolves the missing set through one of two paths per run:

- **Board-based detection** (`findMissingWordsFromBoard`, when the board is in the DB) returned the true missed set: `vert`, `atria`, `vitae`.
- **Dictionary fallback** (`findAllMissingWords`, when the board fetch returns nothing) filters possible words against `currentLevelCorrectWords` — but already-reported missed words are stored there with their display marker (`"vert*"`), which never matches the dictionary word `"vert"`. So the fallback re-derived and re-appended any missed word that exists in the community dictionary. Only VERT was in the dictionary (ATRIA/VITAE weren't), which is exactly why only VERT duplicated.

The two handlers also run concurrently (each `wosWorker.onmessage` invocation is an independent async function that sleeps through the same grace delay before reading board state), so even two same-path runs would double every missed word.

## Fix (three layers)

1. **`logMissingWords` (wos-plus-main.ts)** — before appending, skip any word already displayed, whether guessed or previously starred (comparison is case-insensitive and ignores the `*` marker). The check-and-append is synchronous, so concurrent type-4/type-5 handlers can't both pass it for the same word.
2. **`findMissingWordsFromList` (wos-words.ts)** — strip the `*` marker when building the known-words set, so the dictionary fallback stops re-deriving already-reported missed words at the source.
3. **`findMissingWordsFromBoard` (wos-words.ts)** — track reported words so duplicate slot entries in stored board data can't produce the same missed word twice.

## Tests

- Regression test reproducing the VARIATE scenario: `logMissingWords` runs twice (board path, then dictionary fallback re-deriving `vert`) and each missed word appears exactly once.
- A word already displayed as a plain guess never gains a starred duplicate.
- A detector returning the same word twice (any casing) displays it once.
- `findMissingWordsFromBoard` with duplicate board slots reports the word once.
- `findAllMissingWords` treats `*`-marked known words as already reported.

`pnpm vitest run`: 232 passed, 0 failed.

https://claude.ai/code/session_018h2npzX4eT3SWMW5MGPhpt

---
_Generated by [Claude Code](https://claude.ai/code/session_018h2npzX4eT3SWMW5MGPhpt)_