### PR TITLE
Guard against and self-heal boards saved with redundant words

### DIFF
--- a/db-scripts/add-twitch-channel-to-boards.sql
+++ b/db-scripts/add-twitch-channel-to-boards.sql
@@ -1,0 +1,13 @@
+-- Add a twitch_channel column to the boards table so each board records the
+-- Twitch channel it was captured from.
+--
+-- Usage (via psql or Supabase SQL Editor):
+--   \i db-scripts/add-twitch-channel-to-boards.sql
+--
+-- Or run directly in the Supabase SQL Editor
+--
+-- The column is nullable because boards saved before this change have no
+-- channel information. The self-healing update path (PUT /api/boards/:id)
+-- back-fills it when a corrupted board is replaced with a clean capture.
+
+ALTER TABLE boards ADD COLUMN IF NOT EXISTS twitch_channel TEXT;

--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -32,3 +32,22 @@ export function findRedundantWords(slots: unknown): string[] {
 export function hasRedundantWords(slots: unknown): boolean {
   return findRedundantWords(slots).length > 0;
 }
+
+/**
+ * Normalizes a Twitch channel name for storage on a board (lowercase, no
+ * leading '#'). Returns null when the value isn't a valid Twitch username
+ * (letters, digits, underscores, max 50 chars) so callers can simply omit it —
+ * the channel is informational and must never block a board from saving.
+ */
+export function normalizeTwitchChannel(channel: unknown): string | null {
+  if (typeof channel !== 'string') {
+    return null;
+  }
+
+  const cleanChannel = channel.trim().replace(/^#/, '').toLowerCase();
+  if (!/^[a-z0-9_]{1,50}$/.test(cleanChannel)) {
+    return null;
+  }
+
+  return cleanChannel;
+}

--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -1,0 +1,34 @@
+// Shared helpers for validating board slot data before it is written to the
+// database. Every slot on a Words on Stream board is a distinct word, so a
+// board whose slots contain the same word more than once is corrupted data
+// (issue #119) and must never be inserted as-is.
+
+/**
+ * Returns the words that appear in more than one slot (case-insensitive),
+ * deduplicated. An empty array means the board has no redundant words.
+ * Slots without a usable `word` string are ignored so this can safely run
+ * against unvalidated request bodies.
+ */
+export function findRedundantWords(slots: unknown): string[] {
+  if (!Array.isArray(slots)) {
+    return [];
+  }
+
+  const counts = new Map<string, number>();
+  for (const slot of slots) {
+    const word = slot && typeof slot === 'object' ? (slot as { word?: unknown }).word : undefined;
+    if (typeof word !== 'string' || word.length === 0) {
+      continue;
+    }
+    const key = word.toLowerCase();
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([word]) => word);
+}
+
+export function hasRedundantWords(slots: unknown): boolean {
+  return findRedundantWords(slots).length > 0;
+}

--- a/src/pages/api/boards/[id].ts
+++ b/src/pages/api/boards/[id].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords, hasRedundantWords } from '../../../lib/board-utils';
+import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '../../../lib/board-utils';
 
 export const prerender = false;
 
@@ -153,9 +153,16 @@ export const PUT: APIRoute = async ({ params, request }) => {
       }, 409);
     }
 
+    // Also record (or back-fill) the channel the clean capture came from when
+    // a valid one is provided; invalid values are dropped, not rejected.
+    const cleanTwitchChannel = normalizeTwitchChannel(body?.twitch_channel);
+    const updatePayload = cleanTwitchChannel
+      ? { slots, twitch_channel: cleanTwitchChannel }
+      : { slots };
+
     const { data, error } = await supabase
       .from('boards')
-      .update({ slots })
+      .update(updatePayload)
       .eq('id', cleanId)
       .select();
 

--- a/src/pages/api/boards/[id].ts
+++ b/src/pages/api/boards/[id].ts
@@ -1,44 +1,51 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
+import { findRedundantWords, hasRedundantWords } from '../../../lib/board-utils';
 
 export const prerender = false;
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, PUT, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
 }
 
-export const GET: APIRoute = async ({ params }) => {
-  const { id } = params;
+const jsonResponse = (body: object, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
 
+// Security validation: sanitize and validate board ID.
+// Board IDs should only contain letters (they are words from the game).
+// Returns the cleaned ID, or an error response when validation fails.
+function validateBoardId(id: string | undefined): { cleanId: string } | { errorResponse: Response } {
   if (!id) {
-    return new Response(JSON.stringify({ error: 'Board ID is required' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return { errorResponse: jsonResponse({ error: 'Board ID is required' }, 400) };
   }
 
-  // Security validation: sanitize and validate board ID
-  // Board IDs should only contain letters (they are words from the game)
   const cleanId = id.replace(/\s+/g, '').toUpperCase();
-  
+
   // Validate: only alphabetic characters allowed
   if (!/^[A-Z]+$/.test(cleanId)) {
-    return new Response(JSON.stringify({ error: 'Invalid board ID format. Only letters are allowed.' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return { errorResponse: jsonResponse({ error: 'Invalid board ID format. Only letters are allowed.' }, 400) };
   }
-  
+
   // Validate: reasonable length (game words are typically 4-20 characters)
   if (cleanId.length < 4 || cleanId.length > 20) {
-    return new Response(JSON.stringify({ error: 'Invalid board ID length. Must be between 4 and 20 characters.' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return { errorResponse: jsonResponse({ error: 'Invalid board ID length. Must be between 4 and 20 characters.' }, 400) };
   }
+
+  return { cleanId };
+}
+
+export const GET: APIRoute = async ({ params }) => {
+  const validation = validateBoardId(params.id);
+  if ('errorResponse' in validation) {
+    return validation.errorResponse;
+  }
+  const { cleanId } = validation;
 
   try {
     const supabase = createClient(
@@ -73,5 +80,90 @@ export const GET: APIRoute = async ({ params }) => {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
+  }
+};
+
+// Self-healing update for boards saved with redundant words (issue #119).
+// Only replaces the stored slots when the stored board actually contains the
+// same word in multiple slots AND the incoming slots are clean, so a healthy
+// board can never be overwritten through this endpoint.
+export const PUT: APIRoute = async ({ params, request }) => {
+  const validation = validateBoardId(params.id);
+  if ('errorResponse' in validation) {
+    return validation.errorResponse;
+  }
+  const { cleanId } = validation;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const slots = body?.slots;
+  if (!Array.isArray(slots) || slots.length === 0) {
+    return jsonResponse({ error: 'slots must be a non-empty array' }, 400);
+  }
+
+  const isValidSlots = slots.every(slot =>
+    slot &&
+    typeof slot === 'object' &&
+    Array.isArray(slot.letters) &&
+    typeof slot.word === 'string' &&
+    slot.word.length > 0
+  );
+  if (!isValidSlots) {
+    return jsonResponse({ error: 'Invalid slot structure detected' }, 400);
+  }
+
+  const redundantWords = findRedundantWords(slots);
+  if (redundantWords.length > 0) {
+    return jsonResponse({
+      error: 'Redundant words in board slots',
+      message: `Board ${cleanId} update contains redundant words: ${redundantWords.join(', ')}.`,
+      code: 'REDUNDANT_WORDS',
+    }, 400);
+  }
+
+  try {
+    const supabase = createClient(
+      env.SUPABASE_URL,
+      env.SUPABASE_KEY
+    );
+
+    const { data: existingBoard, error: fetchError } = await supabase
+      .from('boards')
+      .select('*')
+      .eq('id', cleanId)
+      .single();
+
+    if (fetchError) {
+      if (fetchError.code === 'PGRST116') {
+        return jsonResponse({ error: 'Board not found' }, 404);
+      }
+      throw fetchError;
+    }
+
+    if (!hasRedundantWords(existingBoard?.slots)) {
+      return jsonResponse({
+        error: 'Board update not allowed',
+        message: `Board ${cleanId} has no redundant words; refusing to overwrite it.`,
+        code: 'BOARD_UPDATE_NOT_ALLOWED',
+      }, 409);
+    }
+
+    const { data, error } = await supabase
+      .from('boards')
+      .update({ slots })
+      .eq('id', cleanId)
+      .select();
+
+    if (error) throw error;
+
+    return jsonResponse(data ?? []);
+  } catch (error: any) {
+    console.error('Error updating board:', error);
+    return jsonResponse({ error: error.message }, 500);
   }
 };

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
+import { findRedundantWords } from '../../../lib/board-utils';
 
 export const prerender = false;
 const corsHeaders = {
@@ -34,6 +35,23 @@ export const GET: APIRoute = async () => {
 
 export const POST: APIRoute = async ({ request }) => {
   const body = await request.json();
+
+  // Guard (issue #119): reject boards whose slots contain the same word more
+  // than once — that data is corrupted and would need manual cleanup later.
+  const redundantWords = findRedundantWords(body?.slots);
+  if (redundantWords.length > 0) {
+    return new Response(
+      JSON.stringify({
+        error: 'Redundant words in board slots',
+        message: `Board ${body?.id || 'ID'} contains redundant words: ${redundantWords.join(', ')}.`,
+        code: 'REDUNDANT_WORDS',
+      }),
+      {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  }
 
   try {
     const supabase = createClient(

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords } from '../../../lib/board-utils';
+import { findRedundantWords, normalizeTwitchChannel } from '../../../lib/board-utils';
 
 export const prerender = false;
 const corsHeaders = {
@@ -51,6 +51,18 @@ export const POST: APIRoute = async ({ request }) => {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       }
     );
+  }
+
+  // The twitch channel is informational metadata: store the normalized value
+  // when it's a valid channel name, otherwise drop it rather than failing the
+  // save.
+  if ('twitch_channel' in (body ?? {})) {
+    const cleanTwitchChannel = normalizeTwitchChannel(body.twitch_channel);
+    if (cleanTwitchChannel) {
+      body.twitch_channel = cleanTwitchChannel;
+    } else {
+      delete body.twitch_channel;
+    }
   }
 
   try {

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -1,3 +1,5 @@
+import { findRedundantWords, hasRedundantWords } from '../lib/board-utils';
+
 export interface ChannelStats {
   allTimePersonalBest: number;
   dailyBest: number;
@@ -64,21 +66,60 @@ export interface Board {
   created_at: string;
 }
 
-async function boardExists(boardId: string): Promise<boolean> {
+async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; board: Board | null }> {
   const url = `/api/boards/${encodeURIComponent(boardId)}`;
   const response = await fetch(url, {
     method: 'GET',
   });
 
   if (response.status === 404) {
-    return false;
+    return { exists: false, board: null };
   }
 
   if (!response.ok) {
     throw new Error(`Failed to verify board existence: ${response.status} ${response.statusText}`);
   }
 
-  return true;
+  // The board exists; if its body can't be read we still report existence so
+  // the caller falls back to the safe "already saved" path.
+  try {
+    return { exists: true, board: await response.json() };
+  } catch {
+    return { exists: true, board: null };
+  }
+}
+
+// Replaces the slots of an already-stored board that was saved with redundant
+// words (issue #119). The server only accepts this update when the stored
+// board is actually corrupted, so a clean board can never be overwritten.
+async function updateBoardSlots(boardId: string, slots: Slot[]) {
+  try {
+    const response = await fetch(`/api/boards/${encodeURIComponent(boardId)}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ slots }),
+    });
+
+    if (!response.ok) {
+      let errorBody: any = null;
+      try {
+        errorBody = await response.json();
+      } catch {
+        errorBody = null;
+      }
+
+      const apiMessage = errorBody?.message || errorBody?.error;
+      throw new Error(apiMessage || `Network response was not ok: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    console.log(`Board ${boardId} updated with clean slots:`, data);
+    return data;
+  } catch (error) {
+    console.error('Error updating board with clean slots:', error);
+  }
 }
 
 export async function saveBoard(boardId: string, slots: Slot[]) {
@@ -131,9 +172,31 @@ export async function saveBoard(boardId: string, slots: Slot[]) {
     return;
   }
 
+  // Guard (issue #119): every slot on a board is a distinct word, so slots
+  // containing the same word more than once are corrupted capture data and
+  // must never reach the database.
+  const redundantWords = findRedundantWords(slots);
+  if (redundantWords.length > 0) {
+    const redundantMessage = `Cannot save board ${cleanBoardId}: redundant words detected in slots: ${redundantWords.join(', ')}.`;
+    console.warn(redundantMessage);
+    return {
+      error: 'Redundant words in board slots',
+      message: redundantMessage,
+      code: 'REDUNDANT_WORDS',
+    };
+  }
+
   try {
-    const exists = await boardExists(cleanBoardId);
+    const { exists, board: existingBoard } = await fetchExistingBoard(cleanBoardId);
     if (exists) {
+      // Self-healing (issue #119): if the stored copy of this board was saved
+      // with redundant words, replace its slots with this clean capture
+      // instead of skipping the save.
+      if (existingBoard && hasRedundantWords(existingBoard.slots)) {
+        console.warn(`Board ${cleanBoardId} exists with redundant words; updating it with the clean version.`);
+        return await updateBoardSlots(cleanBoardId, slots);
+      }
+
       const duplicateMessage = `Board ${cleanBoardId} has already been saved.`;
       console.warn(duplicateMessage);
       return {

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -1,4 +1,4 @@
-import { findRedundantWords, hasRedundantWords } from '../lib/board-utils';
+import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '../lib/board-utils';
 
 export interface ChannelStats {
   allTimePersonalBest: number;
@@ -64,6 +64,9 @@ export interface Board {
   id: string;
   slots: Slot[];
   created_at: string;
+  // Twitch channel the board was captured from; null for boards saved before
+  // the column existed.
+  twitch_channel?: string | null;
 }
 
 async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; board: Board | null }> {
@@ -92,14 +95,16 @@ async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; b
 // Replaces the slots of an already-stored board that was saved with redundant
 // words (issue #119). The server only accepts this update when the stored
 // board is actually corrupted, so a clean board can never be overwritten.
-async function updateBoardSlots(boardId: string, slots: Slot[]) {
+async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: string | null) {
   try {
     const response = await fetch(`/api/boards/${encodeURIComponent(boardId)}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ slots }),
+      body: JSON.stringify(
+        twitchChannel ? { slots, twitch_channel: twitchChannel } : { slots }
+      ),
     });
 
     if (!response.ok) {
@@ -122,7 +127,7 @@ async function updateBoardSlots(boardId: string, slots: Slot[]) {
   }
 }
 
-export async function saveBoard(boardId: string, slots: Slot[]) {
+export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: string) {
   // Validate boardId is a string and not too long
   if (typeof boardId !== 'string' || boardId.length === 0) {
     console.warn('Cannot save board: boardId must be a non-empty string.');
@@ -186,6 +191,13 @@ export async function saveBoard(boardId: string, slots: Slot[]) {
     };
   }
 
+  // The channel is informational metadata: an invalid or missing value is
+  // dropped rather than blocking the save.
+  const cleanTwitchChannel = normalizeTwitchChannel(twitchChannel);
+  if (twitchChannel !== undefined && cleanTwitchChannel === null) {
+    console.warn('Saving board without twitch channel: channel name is invalid.');
+  }
+
   try {
     const { exists, board: existingBoard } = await fetchExistingBoard(cleanBoardId);
     if (exists) {
@@ -194,7 +206,7 @@ export async function saveBoard(boardId: string, slots: Slot[]) {
       // instead of skipping the save.
       if (existingBoard && hasRedundantWords(existingBoard.slots)) {
         console.warn(`Board ${cleanBoardId} exists with redundant words; updating it with the clean version.`);
-        return await updateBoardSlots(cleanBoardId, slots);
+        return await updateBoardSlots(cleanBoardId, slots, cleanTwitchChannel);
       }
 
       const duplicateMessage = `Board ${cleanBoardId} has already been saved.`;
@@ -220,6 +232,7 @@ export async function saveBoard(boardId: string, slots: Slot[]) {
         id: cleanBoardId,
         slots: slots,
         created_at: new Date().toISOString(),
+        ...(cleanTwitchChannel ? { twitch_channel: cleanTwitchChannel } : {}),
       }),
     });
 

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -406,7 +406,20 @@ export class GameSpectator {
     const history = this.twitchChatLog.get(username.toLowerCase());
     if (!history || history.length === 0) return null;
 
-    const candidates = history.filter(m => !m.consumed && m.message.length === length);
+    // Words already placed in a slot can't be the answer to a new masked
+    // guess — WoS rejects repeat guesses of a word that's already on the
+    // board. Excluding them keeps a re-typed or mis-matched chat message from
+    // filling a second slot with a duplicate word, which is how boards ended
+    // up saved with redundant words (issue #119).
+    const placedWords = new Set(
+      this.currentLevelSlots
+        .filter(slot => slot.user && typeof slot.word === 'string' && slot.word.length > 0)
+        .map(slot => slot.word.toLowerCase())
+    );
+
+    const candidates = history.filter(
+      m => !m.consumed && m.message.length === length && !placedWords.has(m.message.toLowerCase())
+    );
     if (candidates.length === 0) return null;
 
     // Prefer real dictionary words whose letters also fit within the level's

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -330,7 +330,7 @@ export class GameSpectator {
         console.log('[WOS Helper] Board Slots:', this.currentLevelSlots);
         let slots = this.currentLevelSlots;
         if (slots[slots.length - 1].word !== this.currentLevelBigWord) this.currentLevelBigWord = slots[slots.length - 1].word;
-        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots);
+        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots, this.currentChannel);
       }
 
       this.playSound('level_clear');

--- a/tests/unit/board-utils.test.ts
+++ b/tests/unit/board-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findRedundantWords, hasRedundantWords } from '@/lib/board-utils';
+import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '@/lib/board-utils';
 
 /**
  * Unit tests for board-utils.ts module (issue #119)
@@ -80,6 +80,39 @@ describe('board-utils module', () => {
 
     it('should return false for non-array input', () => {
       expect(hasRedundantWords(null)).toBe(false);
+    });
+  });
+
+  describe('normalizeTwitchChannel', () => {
+    it('should lowercase and trim a valid channel name', () => {
+      expect(normalizeTwitchChannel('  Clarkio ')).toBe('clarkio');
+    });
+
+    it('should strip a leading # from the channel name', () => {
+      expect(normalizeTwitchChannel('#clarkio')).toBe('clarkio');
+    });
+
+    it('should accept digits and underscores', () => {
+      expect(normalizeTwitchChannel('some_user123')).toBe('some_user123');
+    });
+
+    it('should return null for invalid characters', () => {
+      expect(normalizeTwitchChannel('bad channel')).toBeNull();
+      expect(normalizeTwitchChannel('bad;drop')).toBeNull();
+      expect(normalizeTwitchChannel('name!')).toBeNull();
+    });
+
+    it('should return null for empty or non-string input', () => {
+      expect(normalizeTwitchChannel('')).toBeNull();
+      expect(normalizeTwitchChannel('#')).toBeNull();
+      expect(normalizeTwitchChannel(null)).toBeNull();
+      expect(normalizeTwitchChannel(undefined)).toBeNull();
+      expect(normalizeTwitchChannel(42)).toBeNull();
+    });
+
+    it('should return null for names longer than 50 characters', () => {
+      expect(normalizeTwitchChannel('a'.repeat(51))).toBeNull();
+      expect(normalizeTwitchChannel('a'.repeat(50))).toBe('a'.repeat(50));
     });
   });
 });

--- a/tests/unit/board-utils.test.ts
+++ b/tests/unit/board-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { findRedundantWords, hasRedundantWords } from '@/lib/board-utils';
+
+/**
+ * Unit tests for board-utils.ts module (issue #119)
+ */
+
+describe('board-utils module', () => {
+  describe('findRedundantWords', () => {
+    it('should return empty array for slots with distinct words', () => {
+      const slots = [
+        { word: 'test' },
+        { word: 'word' },
+        { word: 'board' },
+      ];
+
+      expect(findRedundantWords(slots)).toEqual([]);
+    });
+
+    it('should detect a word that appears in multiple slots', () => {
+      const slots = [
+        { word: 'test' },
+        { word: 'word' },
+        { word: 'test' },
+      ];
+
+      expect(findRedundantWords(slots)).toEqual(['test']);
+    });
+
+    it('should detect redundant words case-insensitively', () => {
+      const slots = [
+        { word: 'Test' },
+        { word: 'TEST' },
+      ];
+
+      expect(findRedundantWords(slots)).toEqual(['test']);
+    });
+
+    it('should report each redundant word once', () => {
+      const slots = [
+        { word: 'test' },
+        { word: 'test' },
+        { word: 'test' },
+        { word: 'word' },
+        { word: 'word' },
+      ];
+
+      expect(findRedundantWords(slots)).toEqual(['test', 'word']);
+    });
+
+    it('should ignore slots without a usable word', () => {
+      const slots = [
+        { word: '' },
+        { word: '' },
+        {},
+        null,
+        { word: 123 },
+        { word: 'test' },
+      ];
+
+      expect(findRedundantWords(slots)).toEqual([]);
+    });
+
+    it('should return empty array for non-array input', () => {
+      expect(findRedundantWords(null)).toEqual([]);
+      expect(findRedundantWords(undefined)).toEqual([]);
+      expect(findRedundantWords('slots')).toEqual([]);
+      expect(findRedundantWords({})).toEqual([]);
+    });
+  });
+
+  describe('hasRedundantWords', () => {
+    it('should return false for clean slots', () => {
+      expect(hasRedundantWords([{ word: 'test' }, { word: 'word' }])).toBe(false);
+    });
+
+    it('should return true when a word is duplicated', () => {
+      expect(hasRedundantWords([{ word: 'test' }, { word: 'test' }])).toBe(true);
+    });
+
+    it('should return false for non-array input', () => {
+      expect(hasRedundantWords(null)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/db-service.test.ts
+++ b/tests/unit/db-service.test.ts
@@ -382,6 +382,154 @@ describe('db-service module', () => {
       });
     });
 
+    describe('redundant words guard (issue #119)', () => {
+      const slotsWithRedundantWords: Slot[] = [
+        {
+          letters: ['t', 'e', 's', 't'],
+          user: 'testuser',
+          hitMax: false,
+          word: 'test',
+        },
+        {
+          letters: ['t', 'e', 's', 't'],
+          user: 'anotheruser',
+          hitMax: false,
+          word: 'test',
+        },
+        {
+          letters: ['w', 'o', 'r', 'd'],
+          user: 'thirduser',
+          hitMax: true,
+          word: 'word',
+        },
+      ];
+
+      it('should reject slots containing the same word in multiple slots without calling the API', async () => {
+        global.fetch = vi.fn();
+
+        const result = await saveBoard('TEST', slotsWithRedundantWords);
+
+        expect(result).toEqual({
+          error: 'Redundant words in board slots',
+          message: 'Cannot save board TEST: redundant words detected in slots: test.',
+          code: 'REDUNDANT_WORDS',
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Cannot save board TEST: redundant words detected in slots: test.'
+        );
+      });
+
+      it('should detect redundant words case-insensitively', async () => {
+        global.fetch = vi.fn();
+
+        const mixedCaseSlots: Slot[] = [
+          {
+            letters: ['t', 'e', 's', 't'],
+            user: 'testuser',
+            hitMax: false,
+            word: 'Test',
+          },
+          {
+            letters: ['T', 'E', 'S', 'T'],
+            user: 'anotheruser',
+            hitMax: false,
+            word: 'TEST',
+          },
+        ];
+
+        const result = await saveBoard('TEST', mixedCaseSlots);
+
+        expect(result).toEqual(
+          expect.objectContaining({ code: 'REDUNDANT_WORDS' })
+        );
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it('should update the existing board when the stored version has redundant words (self-healing)', async () => {
+        const storedCorruptBoard = {
+          id: 'TEST',
+          slots: [
+            { letters: ['t', 'e', 's', 't'], user: 'a', hitMax: false, word: 'test' },
+            { letters: ['t', 'e', 's', 't'], user: 'b', hitMax: false, word: 'test' },
+          ],
+          created_at: '2024-01-01T00:00:00Z',
+        };
+        const updatedBoard = [{ id: 'TEST', slots: validSlots }];
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() => mockFetchResponse(updatedBoard));
+
+        const result = await saveBoard('TEST', validSlots);
+
+        expect(global.fetch).toHaveBeenNthCalledWith(
+          2,
+          '/api/boards/TEST',
+          expect.objectContaining({
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ slots: validSlots }),
+          })
+        );
+        expect(result).toEqual(updatedBoard);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Board TEST exists with redundant words; updating it with the clean version.'
+        );
+      });
+
+      it('should not update the existing board when the stored version is clean', async () => {
+        const storedCleanBoard = {
+          id: 'TEST',
+          slots: validSlots,
+          created_at: '2024-01-01T00:00:00Z',
+        };
+
+        global.fetch = vi.fn(() => mockFetchResponse(storedCleanBoard));
+
+        const result = await saveBoard('TEST', validSlots);
+
+        expect(result).toEqual({
+          error: 'Board already exists',
+          message: 'Board TEST has already been saved.',
+          code: 'BOARD_EXISTS',
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should handle self-healing update failures gracefully', async () => {
+        const storedCorruptBoard = {
+          id: 'TEST',
+          slots: [
+            { letters: ['t', 'e', 's', 't'], user: 'a', hitMax: false, word: 'test' },
+            { letters: ['t', 'e', 's', 't'], user: 'b', hitMax: false, word: 'test' },
+          ],
+          created_at: '2024-01-01T00:00:00Z',
+        };
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              ok: false,
+              status: 500,
+              statusText: 'Internal Server Error',
+              json: () => Promise.resolve({ error: 'Update failed' }),
+            } as Response)
+          );
+
+        const result = await saveBoard('TEST', validSlots);
+
+        expect(result).toBeUndefined();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error updating board with clean slots:',
+          expect.any(Error)
+        );
+      });
+    });
+
     describe('successful save', () => {
       it('should successfully save valid board data', async () => {
         const mockResponse = { success: true, id: 'TEST' };

--- a/tests/unit/db-service.test.ts
+++ b/tests/unit/db-service.test.ts
@@ -530,6 +530,86 @@ describe('db-service module', () => {
       });
     });
 
+    describe('twitch channel capture', () => {
+      it('should include the normalized twitch channel in the POST body', async () => {
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              ok: false,
+              status: 404,
+              statusText: 'Not Found',
+            } as Response)
+          )
+          .mockImplementationOnce(() => mockFetchResponse({ success: true }));
+
+        await saveBoard('TEST', validSlots, '#Clarkio');
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody.twitch_channel).toBe('clarkio');
+      });
+
+      it('should omit the twitch channel when it is invalid', async () => {
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              ok: false,
+              status: 404,
+              statusText: 'Not Found',
+            } as Response)
+          )
+          .mockImplementationOnce(() => mockFetchResponse({ success: true }));
+
+        await saveBoard('TEST', validSlots, 'bad channel!');
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody).not.toHaveProperty('twitch_channel');
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Saving board without twitch channel: channel name is invalid.'
+        );
+      });
+
+      it('should omit the twitch channel when none is provided', async () => {
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              ok: false,
+              status: 404,
+              statusText: 'Not Found',
+            } as Response)
+          )
+          .mockImplementationOnce(() => mockFetchResponse({ success: true }));
+
+        await saveBoard('TEST', validSlots);
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody).not.toHaveProperty('twitch_channel');
+      });
+
+      it('should include the twitch channel in the self-healing update', async () => {
+        const storedCorruptBoard = {
+          id: 'TEST',
+          slots: [
+            { letters: ['t', 'e', 's', 't'], user: 'a', hitMax: false, word: 'test' },
+            { letters: ['t', 'e', 's', 't'], user: 'b', hitMax: false, word: 'test' },
+          ],
+          created_at: '2024-01-01T00:00:00Z',
+        };
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() => mockFetchResponse([{ id: 'TEST', slots: validSlots }]));
+
+        await saveBoard('TEST', validSlots, 'clarkio');
+
+        const putCall = (global.fetch as any).mock.calls[1];
+        expect(putCall[0]).toBe('/api/boards/TEST');
+        expect(JSON.parse(putCall[1].body)).toEqual({
+          slots: validSlots,
+          twitch_channel: 'clarkio',
+        });
+      });
+    });
+
     describe('successful save', () => {
       it('should successfully save valid board data', async () => {
         const mockResponse = { success: true, id: 'TEST' };


### PR DESCRIPTION
Fixes #119

## Root cause investigation

Boards ended up in the database with the same word occupying multiple slots. The most likely source is the hidden-word levels (19+): a masked correct-guess event only reveals the word length and the player, so `resolveGuessedWord` reconstructs the word from that player's recent chat messages. Nothing prevented that resolution from picking a word already placed in another slot — e.g. the player re-typed a word that had already been accepted, or the fallback candidate pool matched the wrong same-length message. The duplicate word then filled a second slot, and `saveBoard` / `POST /api/boards` persisted the corrupted slots verbatim.

## Changes

**Prevent duplicates at the source** (`src/scripts/wos-plus-main.ts`)
- `resolveGuessedWord` now excludes chat candidates whose word is already placed in a slot, since Words on Stream never accepts the same word twice in a level.

**Guard the insert path** (`src/scripts/db-service.ts`, `src/pages/api/boards/index.ts`, `src/lib/board-utils.ts`)
- New shared `findRedundantWords` / `hasRedundantWords` helpers detect case-insensitive duplicate words in slot data.
- `saveBoard` refuses to save slots containing redundant words and returns a `REDUNDANT_WORDS` result.
- `POST /api/boards` rejects such payloads with a 400 as a server-side backstop.

**Self-heal existing corrupted boards** (`src/scripts/db-service.ts`, `src/pages/api/boards/[id].ts`)
- When the board already exists, `saveBoard` now fetches the stored copy and compares it: if the stored slots contain redundant words while the new capture is clean, it replaces the stored slots via a new `PUT /api/boards/:id` endpoint instead of skipping the save. Corrupted boards fix themselves the next time the same board is cleared on stream, with no manual DB edits needed.
- The PUT endpoint validates the board ID and slot structure, rejects payloads with redundant words, and only performs the update when the stored board actually has redundant words (409 otherwise) — so a healthy board can never be overwritten through it.

**Record the Twitch channel a board was captured from** (`db-scripts/add-twitch-channel-to-boards.sql`, `src/lib/board-utils.ts`, `src/scripts/db-service.ts`, `src/scripts/wos-plus-main.ts`, API routes)
- New nullable `twitch_channel` column on `boards` (see migration note below).
- The game spectator passes the connected channel into `saveBoard`, which includes it (normalized: lowercase, no leading `#`) in the POST body. Invalid or missing channel names are dropped rather than blocking the save, on both the client and the server.
- The self-healing PUT also records the channel that provided the clean capture, back-filling rows saved before the column existed.

> **⚠️ Migration required before deploy:** run `db-scripts/add-twitch-channel-to-boards.sql` in the Supabase SQL editor (`ALTER TABLE boards ADD COLUMN IF NOT EXISTS twitch_channel TEXT;`), otherwise inserts that include the new field will fail.

## Tests

- New `tests/unit/board-utils.test.ts` covering the redundant-word detection and channel normalization helpers.
- New `saveBoard` cases in `tests/unit/db-service.test.ts`: guard rejection (no API call), case-insensitive detection, self-healing PUT with a corrupted stored board, no-overwrite when the stored board is clean, graceful handling of a failed self-heal update, and twitch-channel inclusion/omission in both the POST and self-heal PUT bodies.
- Full suite passes: 250 tests, 0 failures.

https://claude.ai/code/session_01Xihp4EbFDkYecCFSM1HABJ