### PR TITLE
Track when a board was last updated with a new updated_at column

### DIFF
--- a/db-scripts/add-updated-at-to-boards.sql
+++ b/db-scripts/add-updated-at-to-boards.sql
@@ -1,0 +1,34 @@
+-- Add an updated_at column to the boards table so each board records when it
+-- was last updated, and a trigger that stamps it automatically on any UPDATE
+-- to a boards row — whether it came from the API (e.g. the self-healing
+-- PUT /api/boards/:id), a db-script, or manual SQL.
+--
+-- Usage (via psql or Supabase SQL Editor):
+--   \i db-scripts/add-updated-at-to-boards.sql
+--
+-- Or run directly in the Supabase SQL Editor
+--
+-- The column is nullable and has no default: NULL means the board has never
+-- been updated since it was saved (created_at already records the save time).
+-- The trigger overrides any client-supplied value, so updated_at is always
+-- server time and can't be spoofed through the API.
+
+ALTER TABLE boards ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+CREATE OR REPLACE FUNCTION set_boards_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS boards_set_updated_at ON boards;
+
+-- The WHEN clause skips no-op updates so updated_at only moves when a row's
+-- data actually changed.
+CREATE TRIGGER boards_set_updated_at
+  BEFORE UPDATE ON boards
+  FOR EACH ROW
+  WHEN (OLD.* IS DISTINCT FROM NEW.*)
+  EXECUTE FUNCTION set_boards_updated_at();

--- a/src/pages/api/boards/[id].ts
+++ b/src/pages/api/boards/[id].ts
@@ -155,6 +155,9 @@ export const PUT: APIRoute = async ({ params, request }) => {
 
     // Also record (or back-fill) the channel the clean capture came from when
     // a valid one is provided; invalid values are dropped, not rejected.
+    // updated_at is intentionally absent from the payload: a database trigger
+    // (db-scripts/add-updated-at-to-boards.sql) stamps it on every UPDATE so
+    // it always reflects server time regardless of how the row was changed.
     const cleanTwitchChannel = normalizeTwitchChannel(body?.twitch_channel);
     const updatePayload = cleanTwitchChannel
       ? { slots, twitch_channel: cleanTwitchChannel }

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -67,6 +67,10 @@ export interface Board {
   // Twitch channel the board was captured from; null for boards saved before
   // the column existed.
   twitch_channel?: string | null;
+  // When the board row was last updated; stamped by a database trigger on any
+  // UPDATE (see db-scripts/add-updated-at-to-boards.sql). Null for boards that
+  // have never been updated since being saved.
+  updated_at?: string | null;
 }
 
 async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; board: Board | null }> {


### PR DESCRIPTION
## Summary

When a board row in the `boards` table is updated, we now track when that happened in a new `updated_at` column.

## Changes

- **`db-scripts/add-updated-at-to-boards.sql`** (new): Adds a nullable `updated_at TIMESTAMPTZ` column to the `boards` table, plus a `BEFORE UPDATE` trigger that stamps it with server time (`NOW()`) on any update to a board row. Run it via the Supabase SQL Editor or psql, same as `add-twitch-channel-to-boards.sql`.
  - The trigger covers every update path — the self-healing `PUT /api/boards/:id` endpoint, db-scripts, and manual SQL — so nothing can update a board without the timestamp moving.
  - A `WHEN (OLD.* IS DISTINCT FROM NEW.*)` clause skips no-op updates, so `updated_at` only changes when the row's data actually changed.
  - The trigger overrides any client-supplied value, so the timestamp is always server time and can't be spoofed through the API.
  - The column is nullable with no default: `NULL` means the board has never been updated since it was saved (`created_at` already records the save time).
- **`src/scripts/db-service.ts`**: Added `updated_at?: string | null` to the `Board` interface so the new column flows through the client typings.
- **`src/pages/api/boards/[id].ts`**: Comment on the `PUT` handler explaining why `updated_at` is intentionally absent from the update payload (the database trigger owns it).

## Deployment note

Run `db-scripts/add-updated-at-to-boards.sql` against the Supabase database to add the column and trigger. The app changes are type/comment-only, so deploy order doesn't matter.

## Testing

- `pnpm test:run`: 250 tests passed
- `pnpm build`: compiles cleanly

https://claude.ai/code/session_01RWnk5stmuT6wqugiqE7iqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWnk5stmuT6wqugiqE7iqL)_