### PR TITLE
fix: parse JSON-string slots so existing-board redundancy check runs

### DIFF
--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -4,18 +4,41 @@
 // (issue #119) and must never be inserted as-is.
 
 /**
+ * The `slots` column comes back from the database as a JSON string rather
+ * than a parsed array, so redundancy checks against stored boards must parse
+ * it first — otherwise every stored board looks clean and the self-healing
+ * update never runs. Returns null when the value can't be read as an array.
+ */
+export function coerceSlots(slots: unknown): unknown[] | null {
+  if (Array.isArray(slots)) {
+    return slots;
+  }
+  if (typeof slots === 'string') {
+    try {
+      const parsed = JSON.parse(slots);
+      return Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
  * Returns the words that appear in more than one slot (case-insensitive),
  * deduplicated. An empty array means the board has no redundant words.
+ * Accepts either a slots array or the JSON string stored in the database.
  * Slots without a usable `word` string are ignored so this can safely run
  * against unvalidated request bodies.
  */
 export function findRedundantWords(slots: unknown): string[] {
-  if (!Array.isArray(slots)) {
+  const slotsArray = coerceSlots(slots);
+  if (!slotsArray) {
     return [];
   }
 
   const counts = new Map<string, number>();
-  for (const slot of slots) {
+  for (const slot of slotsArray) {
     const word = slot && typeof slot === 'object' ? (slot as { word?: unknown }).word : undefined;
     if (typeof word !== 'string' || word.length === 0) {
       continue;

--- a/tests/unit/board-utils.test.ts
+++ b/tests/unit/board-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '@/lib/board-utils';
+import { coerceSlots, findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '@/lib/board-utils';
 
 /**
  * Unit tests for board-utils.ts module (issue #119)
@@ -67,6 +67,22 @@ describe('board-utils module', () => {
       expect(findRedundantWords('slots')).toEqual([]);
       expect(findRedundantWords({})).toEqual([]);
     });
+
+    it('should detect redundant words in a JSON-string slots column', () => {
+      const stored = JSON.stringify([
+        { word: 'test' },
+        { word: 'word' },
+        { word: 'test' },
+      ]);
+
+      expect(findRedundantWords(stored)).toEqual(['test']);
+    });
+
+    it('should return empty array for a clean JSON-string slots column', () => {
+      const stored = JSON.stringify([{ word: 'test' }, { word: 'word' }]);
+
+      expect(findRedundantWords(stored)).toEqual([]);
+    });
   });
 
   describe('hasRedundantWords', () => {
@@ -80,6 +96,33 @@ describe('board-utils module', () => {
 
     it('should return false for non-array input', () => {
       expect(hasRedundantWords(null)).toBe(false);
+    });
+
+    it('should return true for a JSON-string slots column with duplicates', () => {
+      expect(hasRedundantWords(JSON.stringify([{ word: 'test' }, { word: 'test' }]))).toBe(true);
+    });
+  });
+
+  describe('coerceSlots', () => {
+    it('should return an array unchanged', () => {
+      const slots = [{ word: 'test' }];
+      expect(coerceSlots(slots)).toBe(slots);
+    });
+
+    it('should parse a JSON-string array', () => {
+      expect(coerceSlots('[{"word":"test"}]')).toEqual([{ word: 'test' }]);
+    });
+
+    it('should return null for JSON that is not an array', () => {
+      expect(coerceSlots('{"word":"test"}')).toBeNull();
+    });
+
+    it('should return null for invalid JSON and non-slot values', () => {
+      expect(coerceSlots('not json')).toBeNull();
+      expect(coerceSlots(null)).toBeNull();
+      expect(coerceSlots(undefined)).toBeNull();
+      expect(coerceSlots(42)).toBeNull();
+      expect(coerceSlots({})).toBeNull();
     });
   });
 

--- a/tests/unit/db-service.test.ts
+++ b/tests/unit/db-service.test.ts
@@ -480,6 +480,48 @@ describe('db-service module', () => {
         );
       });
 
+      it('should self-heal when the stored slots column is a JSON string with redundant words', async () => {
+        const storedCorruptBoard = {
+          id: 'TEST',
+          slots: JSON.stringify([
+            { letters: ['t', 'e', 's', 't'], user: 'a', hitMax: false, word: 'test' },
+            { letters: ['t', 'e', 's', 't'], user: 'b', hitMax: false, word: 'test' },
+          ]),
+          created_at: '2024-01-01T00:00:00Z',
+        };
+        const updatedBoard = [{ id: 'TEST', slots: validSlots }];
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() => mockFetchResponse(updatedBoard));
+
+        const result = await saveBoard('TEST', validSlots);
+
+        expect(global.fetch).toHaveBeenNthCalledWith(
+          2,
+          '/api/boards/TEST',
+          expect.objectContaining({ method: 'PUT' })
+        );
+        expect(result).toEqual(updatedBoard);
+      });
+
+      it('should not update the existing board when the stored slots column is a clean JSON string', async () => {
+        const storedCleanBoard = {
+          id: 'TEST',
+          slots: JSON.stringify(validSlots),
+          created_at: '2024-01-01T00:00:00Z',
+        };
+
+        global.fetch = vi.fn(() => mockFetchResponse(storedCleanBoard));
+
+        const result = await saveBoard('TEST', validSlots);
+
+        expect(result).toEqual(
+          expect.objectContaining({ code: 'BOARD_EXISTS' })
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
       it('should not update the existing board when the stored version is clean', async () => {
         const storedCleanBoard = {
           id: 'TEST',


### PR DESCRIPTION
## Problem

When saving a board that already exists in the database, the check that verifies the stored board's `slots` contain the correct (non-redundant) words was silently skipped, so the self-healing update from issue #119 never ran.

The `slots` column comes back from Supabase as a **JSON string**, not a parsed array (the `db-scripts/*.mjs` helpers already `JSON.parse` it for this reason). `findRedundantWords` only handled arrays and returned `[]` for any string, which meant:

- **Client (`saveBoard` in `src/scripts/db-service.ts`):** `hasRedundantWords(existingBoard.slots)` was always `false` for stored boards, so a corrupted board was reported as "already saved" instead of being updated with the clean capture.
- **Server (`PUT /api/boards/[id]`):** the guard `!hasRedundantWords(existingBoard?.slots)` always looked clean, so even a direct update attempt was rejected with `BOARD_UPDATE_NOT_ALLOWED` (409).

## Fix

Added `coerceSlots` to `src/lib/board-utils.ts` (mirroring the coercion the db-scripts already do): it accepts an array as-is, parses a JSON-string into an array, and returns `null` for anything else. `findRedundantWords` now coerces its input first, which repairs both call sites at once. Behavior for garbage input (invalid JSON, objects, `null`) is unchanged — still treated as no redundant words.

## Tests

- New unit tests for `coerceSlots` and for JSON-string inputs to `findRedundantWords`/`hasRedundantWords`.
- New `saveBoard` tests: a stored board whose `slots` is a JSON string with duplicate words now triggers the self-healing PUT, and a clean JSON-string board still returns `BOARD_EXISTS` without updating.
- Full suite: 259 passed, 28 todo.

https://claude.ai/code/session_01B1VtqrqToJ1YRNZir2E9mS

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VtqrqToJ1YRNZir2E9mS)_