### PR TITLE
Capture and store the game's word language on saved boards

### DIFF
--- a/db-scripts/add-language-code-to-boards.sql
+++ b/db-scripts/add-language-code-to-boards.sql
@@ -1,0 +1,28 @@
+-- Add a language_code column to the boards table so each board records the
+-- language of the words on it (issue #124).
+--
+-- Words on Stream supports three word languages and indicates the active one
+-- on its socket events as a numeric id. The official wos.gg client resolves
+-- that id through its /api/language?id=N endpoint:
+--   1 -> 'pt' (Português), 2 -> 'en' (English), 4 -> 'fr' (Français)
+-- WoS+ maps the id to the two-letter code client-side (see
+-- src/lib/board-utils.ts) and sends it when saving a board.
+--
+-- Usage (via psql or Supabase SQL Editor):
+--   \i db-scripts/add-language-code-to-boards.sql
+--
+-- Or run directly in the Supabase SQL Editor
+--
+-- The column defaults to 'en': every board saved before language capture
+-- existed came from English games (the only language WoS+ supported), so the
+-- default both back-fills existing rows and covers clients that predate the
+-- language field. The CHECK constraint keeps the column limited to the codes
+-- WoS actually supports; extend it if WoS adds languages. This matches the
+-- words table, which already stores a language_code per word.
+
+ALTER TABLE boards ADD COLUMN IF NOT EXISTS language_code TEXT NOT NULL DEFAULT 'en';
+
+ALTER TABLE boards DROP CONSTRAINT IF EXISTS boards_language_code_check;
+
+ALTER TABLE boards ADD CONSTRAINT boards_language_code_check
+  CHECK (language_code IN ('en', 'pt', 'fr'));

--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -56,6 +56,46 @@ export function hasRedundantWords(slots: unknown): boolean {
   return findRedundantWords(slots).length > 0;
 }
 
+// Words on Stream supports three word languages. The game's socket events
+// carry the language as a numeric id (e.g. on the "Game Connected" payload);
+// the official wos.gg client resolves that id through its /api/language?id=N
+// endpoint, which returns these codes: 1 → 'pt', 2 → 'en', 4 → 'fr'.
+export const WOS_LANGUAGE_ID_TO_CODE: Readonly<Record<number, string>> = {
+  1: 'pt',
+  2: 'en',
+  4: 'fr',
+};
+
+const SUPPORTED_LANGUAGE_CODES = new Set(Object.values(WOS_LANGUAGE_ID_TO_CODE));
+
+/**
+ * Maps the numeric language id from a WoS socket event to its two-letter
+ * language code. Returns null for unknown ids (including future languages WoS
+ * may add) so callers can fall back to their current language instead of
+ * storing a bogus code.
+ */
+export function wosLanguageIdToCode(languageId: unknown): string | null {
+  if (typeof languageId !== 'number' || !Number.isInteger(languageId)) {
+    return null;
+  }
+  return WOS_LANGUAGE_ID_TO_CODE[languageId] ?? null;
+}
+
+/**
+ * Normalizes a language code for storage on a board (lowercase, trimmed).
+ * Returns null when the value isn't one of the languages Words on Stream
+ * supports ('en', 'pt', 'fr') so callers can simply omit it — the language is
+ * informational metadata and must never block a board from saving.
+ */
+export function normalizeLanguageCode(code: unknown): string | null {
+  if (typeof code !== 'string') {
+    return null;
+  }
+
+  const cleanCode = code.trim().toLowerCase();
+  return SUPPORTED_LANGUAGE_CODES.has(cleanCode) ? cleanCode : null;
+}
+
 /**
  * Normalizes a Twitch channel name for storage on a board (lowercase, no
  * leading '#'). Returns null when the value isn't a valid Twitch username

--- a/src/pages/api/boards/[id].ts
+++ b/src/pages/api/boards/[id].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '../../../lib/board-utils';
+import { findRedundantWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../../../lib/board-utils';
 
 export const prerender = false;
 
@@ -158,10 +158,18 @@ export const PUT: APIRoute = async ({ params, request }) => {
     // updated_at is intentionally absent from the payload: a database trigger
     // (db-scripts/add-updated-at-to-boards.sql) stamps it on every UPDATE so
     // it always reflects server time regardless of how the row was changed.
+    // The board's word language (issue #124) is treated the same way: a valid
+    // code is recorded (or back-filled) with the clean capture, an invalid or
+    // missing one leaves the stored value untouched.
     const cleanTwitchChannel = normalizeTwitchChannel(body?.twitch_channel);
-    const updatePayload = cleanTwitchChannel
-      ? { slots, twitch_channel: cleanTwitchChannel }
-      : { slots };
+    const cleanLanguageCode = normalizeLanguageCode(body?.language_code);
+    const updatePayload: Record<string, unknown> = { slots };
+    if (cleanTwitchChannel) {
+      updatePayload.twitch_channel = cleanTwitchChannel;
+    }
+    if (cleanLanguageCode) {
+      updatePayload.language_code = cleanLanguageCode;
+    }
 
     const { data, error } = await supabase
       .from('boards')

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords, normalizeTwitchChannel } from '../../../lib/board-utils';
+import { findRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../../../lib/board-utils';
 
 export const prerender = false;
 const corsHeaders = {
@@ -62,6 +62,18 @@ export const POST: APIRoute = async ({ request }) => {
       body.twitch_channel = cleanTwitchChannel;
     } else {
       delete body.twitch_channel;
+    }
+  }
+
+  // Same treatment for the board's word language (issue #124): store the
+  // normalized code when it's one WoS supports, otherwise drop it so the
+  // column's database default ('en') applies instead of failing the save.
+  if ('language_code' in (body ?? {})) {
+    const cleanLanguageCode = normalizeLanguageCode(body.language_code);
+    if (cleanLanguageCode) {
+      body.language_code = cleanLanguageCode;
+    } else {
+      delete body.language_code;
     }
   }
 

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -1,4 +1,4 @@
-import { findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '../lib/board-utils';
+import { findRedundantWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../lib/board-utils';
 
 export interface ChannelStats {
   allTimePersonalBest: number;
@@ -71,6 +71,11 @@ export interface Board {
   // UPDATE (see db-scripts/add-updated-at-to-boards.sql). Null for boards that
   // have never been updated since being saved.
   updated_at?: string | null;
+  // Two-letter code for the language of the board's words ('en', 'pt' or
+  // 'fr'), captured from the WoS game instance (issue #124). Boards saved
+  // before the column existed default to 'en' — the only language WoS+
+  // supported at the time.
+  language_code?: string | null;
 }
 
 async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; board: Board | null }> {
@@ -99,16 +104,18 @@ async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; b
 // Replaces the slots of an already-stored board that was saved with redundant
 // words (issue #119). The server only accepts this update when the stored
 // board is actually corrupted, so a clean board can never be overwritten.
-async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: string | null) {
+async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: string | null, languageCode: string) {
   try {
     const response = await fetch(`/api/boards/${encodeURIComponent(boardId)}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(
-        twitchChannel ? { slots, twitch_channel: twitchChannel } : { slots }
-      ),
+      body: JSON.stringify({
+        slots,
+        language_code: languageCode,
+        ...(twitchChannel ? { twitch_channel: twitchChannel } : {}),
+      }),
     });
 
     if (!response.ok) {
@@ -131,7 +138,7 @@ async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: s
   }
 }
 
-export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: string) {
+export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: string, languageCode?: string) {
   // Validate boardId is a string and not too long
   if (typeof boardId !== 'string' || boardId.length === 0) {
     console.warn('Cannot save board: boardId must be a non-empty string.');
@@ -202,6 +209,14 @@ export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: 
     console.warn('Saving board without twitch channel: channel name is invalid.');
   }
 
+  // Language is informational metadata too (issue #124): fall back to English
+  // rather than blocking the save, since 'en' was the implicit language of
+  // every board saved before language capture existed.
+  const cleanLanguageCode = normalizeLanguageCode(languageCode) ?? 'en';
+  if (languageCode !== undefined && normalizeLanguageCode(languageCode) === null) {
+    console.warn(`Saving board with default language 'en': language code is invalid.`);
+  }
+
   try {
     const { exists, board: existingBoard } = await fetchExistingBoard(cleanBoardId);
     if (exists) {
@@ -210,7 +225,7 @@ export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: 
       // instead of skipping the save.
       if (existingBoard && hasRedundantWords(existingBoard.slots)) {
         console.warn(`Board ${cleanBoardId} exists with redundant words; updating it with the clean version.`);
-        return await updateBoardSlots(cleanBoardId, slots, cleanTwitchChannel);
+        return await updateBoardSlots(cleanBoardId, slots, cleanTwitchChannel, cleanLanguageCode);
       }
 
       const duplicateMessage = `Board ${cleanBoardId} has already been saved.`;
@@ -236,6 +251,7 @@ export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: 
         id: cleanBoardId,
         slots: slots,
         created_at: new Date().toISOString(),
+        language_code: cleanLanguageCode,
         ...(cleanTwitchChannel ? { twitch_channel: cleanTwitchChannel } : {}),
       }),
     });

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -4,6 +4,7 @@ import io from 'socket.io-client';
 import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord } from './wos-words';
 import { saveBoard, fetchBoard, fetchChannelStats } from './db-service';
 import { getMirrorGameId } from './mirror-url';
+import { wosLanguageIdToCode } from '../lib/board-utils';
 
 
 const twitchWorker = new Worker(
@@ -56,6 +57,12 @@ export class GameSpectator {
   wosSocket: any;
   twitchClient: tmiClient | void = undefined;
   currentChannel: string = '';
+  // Two-letter code for the language of the words in the current game
+  // instance ('en', 'pt' or 'fr'), derived from the numeric language id WoS
+  // includes on its socket events (issue #124). Stored with each saved board
+  // so multi-lingual support can build on the data later. Defaults to English
+  // since that's the only language WoS+ fully supports today.
+  currentLanguageCode: string = 'en';
   personalBest: number = 0;
   dailyBest: number = 0;
   dailyClears: number = 0;
@@ -199,10 +206,19 @@ export class GameSpectator {
     // Set up WOS worker message handler
     wosWorker.onmessage = async (e) => {
       if (e.data.type === 'wos_event') {
-        const { wosEventType, wosEventName, username, letters, hitMax, stars, level, falseLetters, hiddenLetters, slots, index } = e.data;
+        const { wosEventType, wosEventName, username, letters, hitMax, stars, level, falseLetters, hiddenLetters, slots, index, language } = e.data;
 
         const message = username ? `:${username} - ${letters.join('')} - Big Word: ${hitMax}` : '';
         console.log(`[WOS Event] <${wosEventName}>${message}`);
+
+        // Capture the game's word language whenever an event carries it
+        // (issue #124). Unknown/absent ids leave the current value alone so a
+        // mid-game state refresh can't wipe an already-known language.
+        const languageCode = wosLanguageIdToCode(language);
+        if (languageCode && languageCode !== this.currentLanguageCode) {
+          this.currentLanguageCode = languageCode;
+          this.log(`Game language: ${languageCode}`, this.wosGameLogId);
+        }
 
         if (wosEventType === 1 || wosEventType === 12) {
           this.handleGameInitialization(level, wosEventType, letters, slots);
@@ -330,7 +346,7 @@ export class GameSpectator {
         console.log('[WOS Helper] Board Slots:', this.currentLevelSlots);
         let slots = this.currentLevelSlots;
         if (slots[slots.length - 1].word !== this.currentLevelBigWord) this.currentLevelBigWord = slots[slots.length - 1].word;
-        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots, this.currentChannel);
+        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots, this.currentChannel, this.currentLanguageCode);
       }
 
       this.playSound('level_clear');

--- a/src/scripts/wos-worker.ts
+++ b/src/scripts/wos-worker.ts
@@ -15,6 +15,10 @@ export interface WosWorkerMessage {
     slots?: any[];
     index?: number;
     record?: number;
+    // Numeric id of the language the game instance's words are in
+    // (1 = pt, 2 = en, 4 = fr). Present on state-carrying events such as
+    // "Game Connected".
+    language?: number;
   };
 }
 
@@ -32,6 +36,8 @@ export interface WosWorkerResult {
   hiddenLetters: string[];
   slots: any[];
   index?: number;
+  // Passed through untranslated; the main thread maps it to a language code.
+  language?: number;
 }
 
 let currentLevel = 0;
@@ -54,6 +60,7 @@ self.onmessage = function (e: MessageEvent<WosWorkerMessage>) {
       falseLetters: data.falseLetters || [],
       hiddenLetters: data.hiddenLetters || [],
       slots: data.slots || [],
+      language: data.language,
     };
 
     // console.log(`[WOS Worker] Event Type: ${eventType}`, data);

--- a/tests/unit/board-utils.test.ts
+++ b/tests/unit/board-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { coerceSlots, findRedundantWords, hasRedundantWords, normalizeTwitchChannel } from '@/lib/board-utils';
+import { coerceSlots, findRedundantWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel, wosLanguageIdToCode } from '@/lib/board-utils';
 
 /**
  * Unit tests for board-utils.ts module (issue #119)
@@ -156,6 +156,55 @@ describe('board-utils module', () => {
     it('should return null for names longer than 50 characters', () => {
       expect(normalizeTwitchChannel('a'.repeat(51))).toBeNull();
       expect(normalizeTwitchChannel('a'.repeat(50))).toBe('a'.repeat(50));
+    });
+  });
+
+  describe('wosLanguageIdToCode (issue #124)', () => {
+    it('should map the WoS language ids to their codes', () => {
+      expect(wosLanguageIdToCode(1)).toBe('pt');
+      expect(wosLanguageIdToCode(2)).toBe('en');
+      expect(wosLanguageIdToCode(4)).toBe('fr');
+    });
+
+    it('should return null for unknown ids', () => {
+      expect(wosLanguageIdToCode(0)).toBeNull();
+      expect(wosLanguageIdToCode(3)).toBeNull();
+      expect(wosLanguageIdToCode(5)).toBeNull();
+      expect(wosLanguageIdToCode(-1)).toBeNull();
+    });
+
+    it('should return null for non-integer input', () => {
+      expect(wosLanguageIdToCode('2')).toBeNull();
+      expect(wosLanguageIdToCode(2.5)).toBeNull();
+      expect(wosLanguageIdToCode(null)).toBeNull();
+      expect(wosLanguageIdToCode(undefined)).toBeNull();
+      expect(wosLanguageIdToCode({})).toBeNull();
+    });
+  });
+
+  describe('normalizeLanguageCode (issue #124)', () => {
+    it('should accept the supported language codes', () => {
+      expect(normalizeLanguageCode('en')).toBe('en');
+      expect(normalizeLanguageCode('pt')).toBe('pt');
+      expect(normalizeLanguageCode('fr')).toBe('fr');
+    });
+
+    it('should lowercase and trim the code', () => {
+      expect(normalizeLanguageCode('EN')).toBe('en');
+      expect(normalizeLanguageCode(' Fr ')).toBe('fr');
+    });
+
+    it('should return null for unsupported codes', () => {
+      expect(normalizeLanguageCode('es')).toBeNull();
+      expect(normalizeLanguageCode('english')).toBeNull();
+      expect(normalizeLanguageCode('e')).toBeNull();
+    });
+
+    it('should return null for empty or non-string input', () => {
+      expect(normalizeLanguageCode('')).toBeNull();
+      expect(normalizeLanguageCode(null)).toBeNull();
+      expect(normalizeLanguageCode(undefined)).toBeNull();
+      expect(normalizeLanguageCode(2)).toBeNull();
     });
   });
 });

--- a/tests/unit/db-service.test.ts
+++ b/tests/unit/db-service.test.ts
@@ -471,7 +471,7 @@ describe('db-service module', () => {
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ slots: validSlots }),
+            body: JSON.stringify({ slots: validSlots, language_code: 'en' }),
           })
         );
         expect(result).toEqual(updatedBoard);
@@ -647,7 +647,84 @@ describe('db-service module', () => {
         expect(putCall[0]).toBe('/api/boards/TEST');
         expect(JSON.parse(putCall[1].body)).toEqual({
           slots: validSlots,
+          language_code: 'en',
           twitch_channel: 'clarkio',
+        });
+      });
+    });
+
+    describe('language capture (issue #124)', () => {
+      const notFoundThenSuccess = () =>
+        vi.fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              ok: false,
+              status: 404,
+              statusText: 'Not Found',
+            } as Response)
+          )
+          .mockImplementationOnce(() => mockFetchResponse({ success: true }));
+
+      it('should include the language code in the POST body', async () => {
+        global.fetch = notFoundThenSuccess();
+
+        await saveBoard('TEST', validSlots, 'clarkio', 'pt');
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody.language_code).toBe('pt');
+      });
+
+      it('should normalize the language code before sending it', async () => {
+        global.fetch = notFoundThenSuccess();
+
+        await saveBoard('TEST', validSlots, 'clarkio', ' FR ');
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody.language_code).toBe('fr');
+      });
+
+      it('should default to en when no language code is provided', async () => {
+        global.fetch = notFoundThenSuccess();
+
+        await saveBoard('TEST', validSlots);
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody.language_code).toBe('en');
+      });
+
+      it('should default to en when the language code is unsupported', async () => {
+        global.fetch = notFoundThenSuccess();
+
+        await saveBoard('TEST', validSlots, 'clarkio', 'es');
+
+        const requestBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+        expect(requestBody.language_code).toBe('en');
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          `Saving board with default language 'en': language code is invalid.`
+        );
+      });
+
+      it('should include the language code in the self-healing update', async () => {
+        const storedCorruptBoard = {
+          id: 'TEST',
+          slots: [
+            { letters: ['t', 'e', 's', 't'], user: 'a', hitMax: false, word: 'test' },
+            { letters: ['t', 'e', 's', 't'], user: 'b', hitMax: false, word: 'test' },
+          ],
+          created_at: '2024-01-01T00:00:00Z',
+        };
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() => mockFetchResponse([{ id: 'TEST', slots: validSlots }]));
+
+        await saveBoard('TEST', validSlots, undefined, 'fr');
+
+        const putCall = (global.fetch as any).mock.calls[1];
+        expect(putCall[0]).toBe('/api/boards/TEST');
+        expect(JSON.parse(putCall[1].body)).toEqual({
+          slots: validSlots,
+          language_code: 'fr',
         });
       });
     });


### PR DESCRIPTION
Closes #124

## Investigation: how WoS indicates the game's language

Words on Stream carries the language of a game instance's words on its socket events as a **numeric id** — the `language` field on state-carrying payloads such as "Game Connected" (event type 12). The official wos.gg client resolves that id through its own endpoint `https://wos.gg/api/language?id=N`, which returns:

| id | code | language |
|----|------|----------|
| 1 | `pt` | Português |
| 2 | `en` | English |
| 4 | `fr` | Français |

(Verified directly against the wos.gg API and the client bundle, which calls `fetch("/api/language?id=" + e)` whenever an event carries `t.language`.)

## Changes

- **`src/lib/board-utils.ts`**: new `WOS_LANGUAGE_ID_TO_CODE` map plus `wosLanguageIdToCode()` (numeric id → code, `null` for unknown ids) and `normalizeLanguageCode()` (validates/normalizes `en`/`pt`/`fr`, `null` otherwise).
- **`src/scripts/wos-worker.ts`**: passes the event payload's `language` id through to the main thread.
- **`src/scripts/wos-plus-main.ts`**: `GameSpectator` tracks `currentLanguageCode` (default `en`), updating it whenever an event carries a known language id, and sends it with every board save.
- **`src/scripts/db-service.ts`**: `saveBoard()` accepts a language code, normalizes it (falling back to `en`, the implicit language of all pre-existing boards), and includes `language_code` in both the POST body and the issue #119 self-healing PUT. `Board` interface documents the new column.
- **`src/pages/api/boards/index.ts` / `[id].ts`**: normalize `language_code` server-side; invalid values are dropped (DB default / stored value applies) rather than failing the save — same treatment as `twitch_channel`.
- **`db-scripts/add-language-code-to-boards.sql`**: migration adding `language_code TEXT NOT NULL DEFAULT 'en'` with a CHECK constraint on the supported codes. The default back-fills existing boards (all English) and matches the `words` table's existing `language_code` column.

## Tests

- New unit tests for `wosLanguageIdToCode` / `normalizeLanguageCode` and for language capture in `saveBoard` (POST body, normalization, `en` fallback, self-healing PUT).
- Updated the two existing assertions that check the exact self-healing PUT body.
- `pnpm vitest run`: 271 passed, 28 todo.

## Notes

- **Run the migration first**: apply `db-scripts/add-language-code-to-boards.sql` in Supabase before deploying this change — inserting/updating a `language_code` column that doesn't exist yet would make Supabase reject board saves.
- The `words` table already stores `language_code`; `db-scripts/insert-words-from-boards.*` still default to `en` — they can be updated to derive language from `boards.language_code` once non-English boards start being captured.

https://claude.ai/code/session_016yabCkfVm7bA3m5rSthttB