### PR TITLE
fix: key boards by the alphabetically last big word

### DIFF
--- a/db-scripts/fix-board-ids.mjs
+++ b/db-scripts/fix-board-ids.mjs
@@ -47,7 +47,9 @@ function parseArgs(argv) {
 }
 
 function usage() {
-  return `Fix boards.id to match last slot word
+  return `Fix boards.id to match the canonical board id: the alphabetically
+last big word of the board (the level can have several big-word anagrams,
+e.g. LURING and RULING, and sessions may have captured any of them).
 
 If an id update fails due to a duplicate key, the script will fetch the existing row
 for the desired id and compare its slots to the mismatched row's slots (by slot "word" values).
@@ -88,16 +90,35 @@ function coerceSlots(slots) {
   return null;
 }
 
-function getLastSlotWord(slotsArray) {
+// The canonical board id is the alphabetically last big word (see
+// determineBoardId in src/scripts/wos-words.ts). Candidates are the row's
+// max-length slot words plus the row's current id when it is itself an
+// anagram of them — so a row that is already keyed canonically (e.g. RULING)
+// is never re-keyed back to an alphabetically earlier anagram that happened
+// to be captured in its slots (e.g. LURING in the last slot).
+function getDesiredBoardId(currentIdNorm, slotsArray) {
   if (!Array.isArray(slotsArray) || slotsArray.length === 0) return null;
-  const last = slotsArray[slotsArray.length - 1];
-  if (!last || typeof last !== "object") return null;
 
-  if (typeof last.word === "string" && last.word.trim().length > 0) {
-    return last.word;
+  const words = slotsArray
+    .map((slot) => (slot && typeof slot === "object" ? slot.word : null))
+    .map((word) => normalizeId(word))
+    .filter(Boolean);
+
+  if (words.length === 0) return null;
+
+  const maxLength = Math.max(...words.map((word) => word.length));
+  const candidates = new Set(words.filter((word) => word.length === maxLength));
+
+  const signature = [...candidates][0].split("").sort().join("");
+  if (
+    currentIdNorm &&
+    currentIdNorm.length === maxLength &&
+    currentIdNorm.split("").sort().join("") === signature
+  ) {
+    candidates.add(currentIdNorm);
   }
 
-  return null;
+  return [...candidates].sort((a, b) => a.localeCompare(b)).pop();
 }
 
 function isDuplicateKeyError(error) {
@@ -309,17 +330,12 @@ async function main() {
 
       const currentId = row?.id;
       const slotsArray = coerceSlots(row?.slots);
-      const lastWord = getLastSlotWord(slotsArray);
-
-      if (!currentId || !lastWord) {
-        skipped += 1;
-        continue;
-      }
-
       const currentIdNorm = normalizeId(currentId);
-      const desiredIdNorm = normalizeId(lastWord);
+      const desiredIdNorm = currentIdNorm
+        ? getDesiredBoardId(currentIdNorm, slotsArray)
+        : null;
 
-      if (!desiredIdNorm) {
+      if (!currentIdNorm || !desiredIdNorm) {
         skipped += 1;
         continue;
       }
@@ -327,7 +343,7 @@ async function main() {
       if (currentIdNorm !== desiredIdNorm) {
         mismatched += 1;
         console.log(
-          `Mismatch: id=${currentIdNorm} -> slots[last].word=${desiredIdNorm}`
+          `Mismatch: id=${currentIdNorm} -> canonical big word=${desiredIdNorm}`
         );
 
         if (args.apply) {

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -1,7 +1,7 @@
 import tmi, { type Client as tmiClient } from '@tmi.js/chat';
 import io from 'socket.io-client';
 
-import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord } from './wos-words';
+import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord, determineBoardId } from './wos-words';
 import { saveBoard, fetchBoard, fetchChannelStats } from './db-service';
 import { getMirrorGameId } from './mirror-url';
 import { wosLanguageIdToCode } from '../lib/board-utils';
@@ -342,11 +342,13 @@ export class GameSpectator {
       // Capture board data
       if (this.currentLevelBigWord && this.currentLevelSlots) {
         console.log('[WOS Helper] Saving board data to database...');
-        console.log('[WOS Helper] Board ID:', this.currentLevelBigWord);
+        // Save under the canonical id (the alphabetically last big word) —
+        // not whichever anagram happened to be guessed or to sit in the
+        // game's last slot, both of which vary per session.
+        const boardId = this.determineBoardId();
+        console.log('[WOS Helper] Board ID:', boardId);
         console.log('[WOS Helper] Board Slots:', this.currentLevelSlots);
-        let slots = this.currentLevelSlots;
-        if (slots[slots.length - 1].word !== this.currentLevelBigWord) this.currentLevelBigWord = slots[slots.length - 1].word;
-        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots, this.currentChannel, this.currentLanguageCode);
+        await saveBoard(boardId, this.currentLevelSlots, this.currentChannel, this.currentLanguageCode);
       }
 
       this.playSound('level_clear');
@@ -488,8 +490,21 @@ export class GameSpectator {
 
     // Try to fetch board data if we have a big word
     if (this.currentLevelBigWord !== '') {
-      console.log('Attempting to fetch board with ID:', this.currentLevelBigWord);
-      const board = await fetchBoard(this.currentLevelBigWord);
+      // Look the board up under its canonical id (the alphabetically last big
+      // word): the guessed big word may be a different anagram of the id the
+      // board was stored under (e.g. LURING guessed, board saved as RULING).
+      const boardId = this.determineBoardId();
+      console.log('Attempting to fetch board with ID:', boardId);
+      let board = await fetchBoard(boardId);
+
+      // Boards saved before ids were canonicalized are keyed by whichever big
+      // word that session happened to capture, so retry with the guessed word
+      // before falling back to dictionary-based detection.
+      const guessedBoardId = this.currentLevelBigWord.replace(/\s+/g, '').toUpperCase();
+      if (!board && guessedBoardId !== boardId) {
+        console.log('Board not found under canonical ID, retrying with guessed big word:', guessedBoardId);
+        board = await fetchBoard(guessedBoardId);
+      }
 
       if (board && board.slots) {
         console.log('Board found in database, using board slots for missed words detection');
@@ -697,6 +712,17 @@ export class GameSpectator {
           this.currentLevelHiddenLetters.map(l => l.toUpperCase()).join(' ');
       }
     }
+  }
+
+  // Canonical database id for the current board: the alphabetically last big
+  // word of the level. Filled slot words are passed as extra candidates so a
+  // big-word anagram captured in a slot still wins even when the dictionary
+  // hasn't loaded (determineBoardId ignores non-anagram words).
+  private determineBoardId(): string {
+    const slotWords = this.currentLevelSlots
+      .filter(slot => typeof slot.word === 'string' && slot.word.length > 0)
+      .map(slot => slot.word);
+    return determineBoardId(this.currentLevelBigWord, slotWords);
   }
 
   private updateCurrentLevelSlots(username: string, letters: string[], index: number, hitMax: boolean) {

--- a/src/scripts/wos-words.ts
+++ b/src/scripts/wos-words.ts
@@ -62,6 +62,51 @@ export interface Slot {
   length?: number;
 }
 
+/**
+ * Determines the canonical database id for a board: the alphabetically last
+ * big word of the level. A level can have several valid big words — anagrams
+ * of the same letters, e.g. LURING and RULING — and which one players happen
+ * to guess (or which one lands in the game's final slot) varies per session.
+ * Keying boards by the anagram that sorts last alphabetically makes every
+ * session derive the same id for the same board, on save and on lookup.
+ *
+ * Candidates are the dictionary anagrams of `bigWord` plus any
+ * `extraCandidates` observed during play (e.g. filled slot words); candidates
+ * that aren't anagrams of `bigWord` are ignored. Falls back to `bigWord`
+ * itself when the dictionary hasn't loaded and nothing else qualifies.
+ * Returns the id uppercased with any display spaces removed.
+ */
+export function determineBoardId(bigWord: string, extraCandidates: string[] = []): string {
+  const cleanBigWord = bigWord.replace(/\s+/g, '').toLowerCase();
+  if (cleanBigWord.length === 0) {
+    return '';
+  }
+
+  const signature = cleanBigWord.split('').sort().join('');
+  const isAnagram = (word: string) =>
+    word.length === cleanBigWord.length && word.split('').sort().join('') === signature;
+
+  const candidates = new Set<string>([cleanBigWord]);
+
+  for (const candidate of extraCandidates) {
+    const clean = candidate.replace(/\s+/g, '').toLowerCase();
+    if (isAnagram(clean)) {
+      candidates.add(clean);
+    }
+  }
+
+  if (wosDictionary) {
+    for (const word of wosDictionary) {
+      const clean = word.toLowerCase();
+      if (isAnagram(clean)) {
+        candidates.add(clean);
+      }
+    }
+  }
+
+  return [...candidates].sort((a, b) => a.localeCompare(b)).pop()!.toUpperCase();
+}
+
 export async function updateWordsDb(word: string) {
   try {
     if (wosDictionary && wosDictionary.includes(word)) {

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -28,6 +28,10 @@ vi.mock('@scripts/wos-words', async (importActual) => {
     // dependency, so hidden-word resolution genuinely validates that a candidate
     // fits within the level's letters.
     canFormWord: actual.canFormWord,
+    // Keep the real board-id canonicalization too: with the dictionary unloaded
+    // in tests it works purely from the big word and the slot-word candidates,
+    // so save/fetch key derivation is genuinely exercised.
+    determineBoardId: actual.determineBoardId,
   };
 });
 
@@ -910,6 +914,30 @@ describe('GameSpectator class', () => {
       expect(document.getElementById('level-title')!.innerText).toBe('NEXT LEVEL');
       expect(document.getElementById('level-value')!.innerText).toBe('13');
     });
+
+    it('should save a cleared board under the alphabetically last big word', async () => {
+      // The level has two big words (anagrams LURING and RULING). LURING was
+      // the guessed big word and also sits in the game's last slot, but the
+      // canonical board id must be RULING — the alphabetically last anagram.
+      const dbService = await import('@scripts/db-service');
+      const saveBoardMock = vi.mocked(dbService.saveBoard);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'i', 'n', 'g'], word: 'ring', user: 'user1', hitMax: false, index: 0, length: 4 },
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user2', hitMax: true, index: 1, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: 'luring', user: 'user3', hitMax: true, index: 2, length: 6 },
+      ];
+
+      await (spectator as any).handleLevelResults(5);
+
+      expect(saveBoardMock).toHaveBeenCalledWith(
+        'RULING',
+        spectator.currentLevelSlots,
+        spectator.currentChannel,
+        spectator.currentLanguageCode
+      );
+    });
   });
 
   describe('handleLevelEnd', () => {
@@ -1167,7 +1195,9 @@ describe('GameSpectator class', () => {
 
       await (spectator as any).logMissingWords();
 
-      expect(fetchBoardMock).toHaveBeenCalledWith('T E S T I N G');
+      // The board is looked up under its canonical id: spaces removed,
+      // alphabetically last anagram.
+      expect(fetchBoardMock).toHaveBeenCalledWith('TESTING');
       expect(findAllMissingWordsMock).toHaveBeenCalledTimes(1);
       expect(spectator.currentLevelCorrectWords).toEqual(
         expect.arrayContaining(['alpha*', 'beta*'])
@@ -1243,13 +1273,71 @@ describe('GameSpectator class', () => {
 
       await (spectator as any).logMissingWords();
 
-      expect(fetchBoardMock).toHaveBeenCalledWith('T E S T I N G');
+      expect(fetchBoardMock).toHaveBeenCalledWith('TESTING');
       expect(findMissingWordsFromBoardMock).toHaveBeenCalledWith(
         spectator.currentLevelSlots,
         mockBoard.slots
       );
       expect(spectator.currentLevelCorrectWords).toEqual(
         expect.arrayContaining(['miss*'])
+      );
+    });
+
+    it('should fetch the board under the alphabetically last big word anagram', async () => {
+      // RULING was captured in a slot while LURING is the guessed big word:
+      // the lookup must use RULING, the canonical (alphabetically last) id.
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      fetchBoardMock.mockResolvedValueOnce({
+        id: 'RULING',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [],
+      });
+      vi.mocked(wosWords.findMissingWordsFromBoard).mockReturnValueOnce([]);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user1', hitMax: true, index: 0, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: '', hitMax: false, index: 1, length: 6 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(fetchBoardMock).toHaveBeenCalledTimes(1);
+      expect(fetchBoardMock).toHaveBeenCalledWith('RULING');
+    });
+
+    it('should retry the fetch with the guessed big word when the canonical id is not stored', async () => {
+      // Boards saved before ids were canonicalized are keyed by whichever big
+      // word that session captured — here the board is stored as LURING.
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      const legacyBoard = {
+        id: 'LURING',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [
+          { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: 'luring', user: 'user1', hitMax: true, index: 0, length: 6 },
+        ],
+      };
+      fetchBoardMock.mockResolvedValueOnce(null); // canonical id RULING not found
+      fetchBoardMock.mockResolvedValueOnce(legacyBoard);
+
+      const findMissingWordsFromBoardMock = vi.mocked(wosWords.findMissingWordsFromBoard);
+      findMissingWordsFromBoardMock.mockReturnValueOnce([]);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user1', hitMax: true, index: 0, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: '', hitMax: false, index: 1, length: 6 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(fetchBoardMock).toHaveBeenNthCalledWith(1, 'RULING');
+      expect(fetchBoardMock).toHaveBeenNthCalledWith(2, 'LURING');
+      expect(findMissingWordsFromBoardMock).toHaveBeenCalledWith(
+        spectator.currentLevelSlots,
+        legacyBoard.slots
       );
     });
 

--- a/tests/unit/wos-words.test.ts
+++ b/tests/unit/wos-words.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { findMissingWordsFromBoard, canFormWord } from '@scripts/wos-words';
+import { findMissingWordsFromBoard, canFormWord, determineBoardId, loadWordsFromDb } from '@scripts/wos-words';
 import type { Slot } from '@scripts/wos-words';
 
 /**
@@ -25,6 +25,49 @@ describe('wos-words module', () => {
     it.todo('should identify missing words from a level');
     it.todo('should respect minimum word length');
     it.todo('should handle known letters correctly');
+  });
+
+  describe('determineBoardId', () => {
+    it('should return the big word itself when no other candidates exist', () => {
+      expect(determineBoardId('TESTING')).toBe('TESTING');
+    });
+
+    it('should strip display spaces and uppercase the id', () => {
+      expect(determineBoardId('l u r i n g')).toBe('LURING');
+    });
+
+    it('should return empty string for an empty big word', () => {
+      expect(determineBoardId('')).toBe('');
+      expect(determineBoardId('   ')).toBe('');
+    });
+
+    it('should pick the alphabetically last anagram among extra candidates', () => {
+      expect(determineBoardId('L U R I N G', ['ruling'])).toBe('RULING');
+      // Order of arguments must not matter — RULING wins either way.
+      expect(determineBoardId('RULING', ['luring'])).toBe('RULING');
+    });
+
+    it('should ignore extra candidates that are not anagrams of the big word', () => {
+      expect(determineBoardId('LURING', ['ring', 'unruly', 'zzzzzz'])).toBe('LURING');
+    });
+
+    it('should pick the alphabetically last anagram from the loaded dictionary', async () => {
+      // Seed the module's dictionary the same way production does.
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(['luring', 'ruling', 'unrig', 'ring']),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      try {
+        await loadWordsFromDb();
+        // RULING was never guessed nor passed as a candidate, but the
+        // dictionary knows it is an anagram of LURING and it sorts last.
+        expect(determineBoardId('L U R I N G')).toBe('RULING');
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
   });
 
   describe('findMissingWordsFromBoard', () => {


### PR DESCRIPTION
## Problem

A level can have several valid big words that are anagrams of the same letters (e.g. with valid letters L, I, R, N, G, U both **LURING** and **RULING** are big words), and the board id was derived inconsistently:

- **Save path** (`handleLevelResults`): the id was silently overridden with whatever word sat in the game's **last slot** — order-dependent, and on hidden levels (19+) it's whichever anagram was reconstructed from chat.
- **Fetch path** (`logMissingWords`): the lookup used whichever big word happened to be **guessed** (`currentLevelBigWord`), with no canonicalization at all. Guessing LURING when the board was stored as RULING made the lookup miss and missed-word detection silently fell back to the less accurate dictionary-based path.
- **Logging**: `[WOS Helper] Board ID:` was printed *before* the last-slot override, so the log could show a different id (`L U R I N G`) than the one actually saved. The reported symptom was both a logging issue **and** a real logic issue.

## Changes

- Added `determineBoardId(bigWord, extraCandidates)` to `wos-words.ts`: returns the canonical board id — the **alphabetically last big word** — chosen among the dictionary anagrams of the big word plus any observed candidates (non-anagram candidates are ignored). Falls back to the big word itself when nothing else qualifies.
- `GameSpectator` now derives the id the same way on **save and fetch**, passing the level's filled slot words as extra candidates, and logs the id actually used.
- Board lookups that miss under the canonical id **retry with the guessed big word**, so boards saved under the old convention are still found.
- `db-scripts/fix-board-ids.mjs` now targets the same canonical id (alphabetically last among a row's max-length slot words and its current id) instead of the raw last-slot word — previously a `--apply` run could have re-keyed a canonical `RULING` row back to `LURING`.

## Tests

- New unit tests for `determineBoardId` (dictionary-driven and candidate-driven anagram selection, normalization, non-anagram rejection).
- New `GameSpectator` tests: cleared boards save under the alphabetically last big word; lookups use the canonical id and fall back to the guessed id for legacy boards.
- Full suite passes (280 tests) and `pnpm build` succeeds.

https://claude.ai/code/session_01RB91Sz2MstQEJeNsBfpW5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01RB91Sz2MstQEJeNsBfpW5C)_