### PR TITLE
Record unrecoverable hidden mobile guesses as solved, not missed (#143)

### DIFF
--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -229,7 +229,7 @@ export class GameSpectator {
           // Wait for any last-millisecond correct guesses still in the queue
           // to process before reading the board state for results.
           await new Promise(resolve => setTimeout(resolve, this.levelEndGraceDelay));
-          await this.handleLevelResults(stars);
+          await this.handleLevelResults(stars, slots);
           // Delay to allow the chatbot to update the DB before reading
           await new Promise(resolve => setTimeout(resolve, 1500));
           await this.refreshChannelStats();
@@ -237,7 +237,7 @@ export class GameSpectator {
           // Wait for any last-millisecond correct guesses still in the queue
           // to process before running the game-end logic.
           await new Promise(resolve => setTimeout(resolve, this.levelEndGraceDelay));
-          await this.handleLevelEnd();
+          await this.handleLevelEnd(slots);
           await new Promise(resolve => setTimeout(resolve, 1500));
           await this.refreshChannelStats();
         } else if (wosEventType === 10) {
@@ -297,7 +297,10 @@ export class GameSpectator {
     }
   }
 
-  private async handleLevelEnd() {
+  private async handleLevelEnd(revealedSlots: any[] = []) {
+    // The game reveals the board's words as it ends; fill in any slots we'd only
+    // recorded as masked hidden guesses (issue #143) before running end logic.
+    this.reconcileRevealedSlots(revealedSlots);
     this.log(`Game Ended on Level ${this.currentLevel}`, this.wosGameLogId);
 
     await this.logMissingWords();
@@ -325,7 +328,11 @@ export class GameSpectator {
     });
   }
 
-  private async handleLevelResults(stars: any) {
+  private async handleLevelResults(stars: any, revealedSlots: any[] = []) {
+    // If the WoS game revealed the board's words before the level ended, fill in
+    // any slots we'd only recorded as masked hidden guesses (issue #143) so they
+    // count as solved with their real word rather than a '????' placeholder.
+    this.reconcileRevealedSlots(revealedSlots);
     this.log(`Level ${this.currentLevel} ended with ${stars} stars`, this.wosGameLogId);
     console.log(`[WOS Helper] Level ${this.currentLevel} ended`);
     this.log(`[WOS Helper] Total slots for level ${this.currentLevel}: ${this.currentLevelSlots.length}`, this.wosGameLogId);
@@ -574,6 +581,15 @@ export class GameSpectator {
 
     this.log(`[WOS Event] ${lowerUsername} correctly guessed: ${word}`, this.wosGameLogId);
 
+    // If this resolves a slot we'd previously recorded as a masked hidden guess
+    // (issue #143) — e.g. the WoS game revealed the word before the level ended,
+    // or chat resolution caught up — drop the obsolete '????' placeholder so the
+    // real word replaces it instead of showing alongside it.
+    const maskedSlot = this.currentLevelSlots[index];
+    if (maskedSlot && typeof maskedSlot.word === 'string' && maskedSlot.word.includes('?')) {
+      this.removeMaskedPlaceholder(maskedSlot.word.length);
+    }
+
     // Add to correct words list
     this.updateCorrectWordsDisplayed(word);
     this.updateCurrentLevelSlots(username, word.split(''), index, hitMax);
@@ -727,6 +743,66 @@ export class GameSpectator {
   private recordUnknownHiddenGuess(username: string, letters: string[], index: number, hitMax: boolean) {
     this.updateCurrentLevelSlots(username, letters, index, hitMax);
     this.updateCorrectWordsDisplayed(letters.join(''));
+  }
+
+  // Remove a single masked placeholder ('????') of the given length from the
+  // correct-words list. Used when the real word for a previously-masked hidden
+  // guess becomes known, so the placeholder is replaced rather than duplicated.
+  // Same-length placeholders are interchangeable, so removing any one of them
+  // keeps the per-length count correct.
+  private removeMaskedPlaceholder(length: number): boolean {
+    const placeholder = '?'.repeat(length);
+    const idx = this.currentLevelCorrectWords.indexOf(placeholder);
+    if (idx === -1) return false;
+    this.currentLevelCorrectWords.splice(idx, 1);
+    return true;
+  }
+
+  // Pull a usable word out of a raw WoS slot, preferring its `word` field and
+  // falling back to joining its `letters`. Returns '' when neither is present.
+  private extractSlotWord(slot: any): string {
+    if (!slot) return '';
+    if (typeof slot.word === 'string' && slot.word.length > 0) return slot.word;
+    if (Array.isArray(slot.letters)) return slot.letters.join('');
+    return '';
+  }
+
+  // Fill in slots we'd recorded as masked hidden guesses (issue #143) once the
+  // WoS game reveals the real words before the level ends. `revealedSlots` is
+  // the game's authoritative board state (as carried on level-results / level-
+  // end events). For every position where our slot is still masked ('????') but
+  // the revealed slot carries a real word, replace the placeholder with the real
+  // word, keeping the original guesser. Genuinely-unsolved slots are left
+  // untouched so end-of-level missed-word detection still runs for them.
+  private reconcileRevealedSlots(revealedSlots: any[]) {
+    if (!Array.isArray(revealedSlots) || revealedSlots.length === 0) return;
+
+    revealedSlots.forEach((revealed, position) => {
+      const index = typeof revealed?.index === 'number' ? revealed.index : position;
+      const current = this.currentLevelSlots[index];
+      // Only backfill slots we previously masked; never overwrite a real word or
+      // fill a genuinely-unsolved slot (those must stay for missed-word logic).
+      if (!current || typeof current.word !== 'string' || !current.word.includes('?')) {
+        return;
+      }
+
+      const revealedWord = this.extractSlotWord(revealed);
+      if (!revealedWord || revealedWord.includes('?')) {
+        return; // nothing usable was revealed for this slot
+      }
+
+      this.removeMaskedPlaceholder(current.word.length);
+      this.currentLevelSlots[index] = {
+        letters: revealedWord.split(''),
+        word: revealedWord,
+        user: current.user || revealed?.user || '',
+        hitMax: current.hitMax || !!revealed?.hitMax,
+        index,
+        length: revealedWord.length,
+      };
+      this.updateCorrectWordsDisplayed(revealedWord);
+      this.log(`[WOS Event] Revealed hidden word for slot ${index}: ${revealedWord}`, this.wosGameLogId);
+    });
   }
 
   private updateCurrentLevelSlots(username: string, letters: string[], index: number, hitMax: boolean) {

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -240,6 +240,14 @@ export class GameSpectator {
           await this.handleLevelEnd(slots);
           await new Promise(resolve => setTimeout(resolve, 1500));
           await this.refreshChannelStats();
+        } else if (wosEventType === 8) {
+          // 'Level Ended' fires as the game closes out a level and reveals the
+          // board. It carries no state we act on beyond the revealed slots, so
+          // we only reconcile masked hidden guesses here (issue #143) and leave
+          // the end-of-level logic to events 4/5. Reconciliation is idempotent
+          // and a no-op when the event carries no usable slot data, so routing
+          // this event is safe regardless of which event actually reveals.
+          this.reconcileRevealedSlots(slots);
         } else if (wosEventType === 10) {
           this.handleLetterReveal(hiddenLetters, falseLetters);
         }
@@ -333,6 +341,7 @@ export class GameSpectator {
     // any slots we'd only recorded as masked hidden guesses (issue #143) so they
     // count as solved with their real word rather than a '????' placeholder.
     this.reconcileRevealedSlots(revealedSlots);
+    this.logUnresolvedMaskedSlots();
     this.log(`Level ${this.currentLevel} ended with ${stars} stars`, this.wosGameLogId);
     console.log(`[WOS Helper] Level ${this.currentLevel} ended`);
     this.log(`[WOS Helper] Total slots for level ${this.currentLevel}: ${this.currentLevelSlots.length}`, this.wosGameLogId);
@@ -803,6 +812,25 @@ export class GameSpectator {
       this.updateCorrectWordsDisplayed(revealedWord);
       this.log(`[WOS Event] Revealed hidden word for slot ${index}: ${revealedWord}`, this.wosGameLogId);
     });
+  }
+
+  // Diagnostic for issue #143: report slots still carrying a masked '????' once
+  // the level is over. WoS is not documented to hand revealed words to
+  // spectators (it's why this tool needs a boards DB and a dictionary fallback
+  // at all), so this makes it visible from a single real session whether any
+  // event actually delivers them — and which masked guesses went unrecovered.
+  private logUnresolvedMaskedSlots() {
+    const masked = this.currentLevelSlots.filter(
+      slot => slot && typeof slot.word === 'string' && slot.word.includes('?')
+    );
+    if (masked.length === 0) return;
+
+    this.log(
+      `${masked.length} hidden guess(es) never revealed: ${masked
+        .map(slot => `slot ${slot.index} (${slot.word.length} letters, ${slot.user || 'unknown'})`)
+        .join(', ')}`,
+      this.wosGameLogId
+    );
   }
 
   private updateCurrentLevelSlots(username: string, letters: string[], index: number, hitMax: boolean) {

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -556,11 +556,19 @@ export class GameSpectator {
       if (resolved) {
         word = resolved;
       } else {
+        // Mobile players submit guesses in the WoS app (play.wos.gg) rather than
+        // Twitch chat, so on hidden levels (19+) there's no chat message to
+        // reconstruct their masked word from (issue #143). Dropping the guess
+        // here made its slot read as a *missed* word at level end, which is
+        // wrong — the slot was actually solved. Record it as solved by this
+        // user with the word left masked so the missed/empty-word tallies stay
+        // honest, even though the exact word can't be recovered.
         console.warn(
-          `[WOS Helper] Could not find matching message for ${lowerUsername}`,
+          `[WOS Helper] Could not recover hidden word for ${lowerUsername}; recording slot as solved with a masked word.`,
           `[WOS Helper] Chat history: ${JSON.stringify(this.twitchChatLog.get(lowerUsername))}`
         );
-        return; // Skip updating UI if we can't find the word
+        this.recordUnknownHiddenGuess(lowerUsername, letters, index, hitMax);
+        return;
       }
     }
 
@@ -607,8 +615,11 @@ export class GameSpectator {
       const correctLettersFrequency = new Map<string, number>();
 
       this.currentLevelCorrectWords.forEach(word => {
-        // Skip words marked with * (these are missing words added by the system)
-        if (!word.includes('*')) {
+        // Skip system-added missing words ('*') and masked hidden guesses whose
+        // text we couldn't recover ('?', issue #143). Neither is a real guessed
+        // word, so feeding them into hidden-letter frequency inference would
+        // corrupt it (e.g. registering '?' itself as a hidden letter).
+        if (!word.includes('*') && !word.includes('?')) {
           // Count letter frequencies in this specific word
           const wordLetterFrequency = new Map<string, number>();
           const letters = word.toLowerCase().split('');
@@ -699,6 +710,25 @@ export class GameSpectator {
     }
   }
 
+  // Record a hidden-level (19+) correct guess whose word we couldn't recover.
+  // Mobile players submit guesses in the WoS app rather than Twitch chat
+  // (issue #143), so there's no message to un-mask their word — but the WoS
+  // event still tells us who guessed and which slot (index) plus how many
+  // letters. We mark that slot solved by the user with the word left masked
+  // ('????'), which:
+  //   - keeps it out of the missed/empty-word tallies (those key off slot.user),
+  //   - shows a distinct masked placeholder chip in the correct-words log, and
+  //   - never reaches the boards table (saveBoard rejects any '?'-bearing slot),
+  //     so a masked word can't corrupt saved board data.
+  // The exact word stays unknown, so the dictionary-fallback missed-word path
+  // (used only when the board isn't in the DB) may still list it — we have no
+  // text to exclude it by. The board-based path excludes it correctly via
+  // slot.user.
+  private recordUnknownHiddenGuess(username: string, letters: string[], index: number, hitMax: boolean) {
+    this.updateCurrentLevelSlots(username, letters, index, hitMax);
+    this.updateCorrectWordsDisplayed(letters.join(''));
+  }
+
   private updateCurrentLevelSlots(username: string, letters: string[], index: number, hitMax: boolean) {
     // Update the current level slots with the correct guess word
     if (index >= 0 && index < this.currentLevelSlots.length) {
@@ -781,10 +811,20 @@ export class GameSpectator {
         wordsContainer.className = 'word-group__words';
 
         words.forEach(current => {
+          const isMissing = current.endsWith('*');
+          // A masked entry ('????') is a hidden guess we recorded as solved but
+          // couldn't un-mask (issue #143). Style it distinctly from both real
+          // correct words and missed words so it reads as "a word was found
+          // here, text unknown".
+          const isHidden = !isMissing && current.includes('?');
           const displayWord = current.replace('*', '').toUpperCase();
           const wordEl = document.createElement('span');
-          wordEl.className = `correct-word${current.endsWith('*') ? ' missing-word' : ''}`;
-          wordEl.textContent = `${displayWord}${current.endsWith('*') ? '*' : ''}`;
+          const modifier = isMissing ? ' missing-word' : isHidden ? ' hidden-word' : '';
+          wordEl.className = `correct-word${modifier}`;
+          wordEl.textContent = `${displayWord}${isMissing ? '*' : ''}`;
+          if (isHidden) {
+            wordEl.title = 'Hidden guess — word not captured (mobile player)';
+          }
           wordsContainer.appendChild(wordEl);
         });
 

--- a/src/styles/wos-shared.css
+++ b/src/styles/wos-shared.css
@@ -204,6 +204,19 @@ body {
   color: var(--missing-text);
 }
 
+/* A hidden (level 19+) guess whose exact word we couldn't recover — mobile
+   players submit guesses in the WoS app rather than Twitch chat, so there's no
+   message to reconstruct the masked word from (issue #143). Rendered as a
+   masked placeholder ("????") with a dashed outline so it clearly reads as "a
+   word was found here, text unknown" and is never mistaken for a real correct
+   or missed word. `outline` (not `border`) is used so it shows even in themes
+   whose chips have no border width. */
+.correct-word.hidden-word {
+  outline: 2px dashed currentColor;
+  outline-offset: -3px;
+  opacity: 0.85;
+}
+
 /* Scale correct-word sizing based on the word-log container size so
    words fill the available space dynamically */
 @container word-log (min-width: 300px) {

--- a/src/styles/wos-theme-sticker-pop.css
+++ b/src/styles/wos-theme-sticker-pop.css
@@ -236,6 +236,16 @@
   color: var(--sp-bg-deep);
 }
 
+/* Hidden guess whose word couldn't be recovered (mobile players guess in the
+   WoS app, not chat — issue #143). Cyan chip with the shared dashed outline so
+   it reads as "a word was found here, text unknown" — distinct from both the
+   purple found-word chips and the pink missed-word chips. */
+[data-theme="sticker-pop"] .player-bottom-container .correct-word.hidden-word,
+[data-theme="sticker-pop"] .streamer-bottom-container .correct-word.hidden-word {
+  background: var(--sp-cyan);
+  color: var(--sp-bg-deep);
+}
+
 /* --- Letters panel: dark block with cyan offset shadow ------------------- */
 [data-theme="sticker-pop"] .level-data-container {
   background: var(--sp-bg-deep);

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -439,6 +439,64 @@ describe('GameSpectator class', () => {
       expect(spectator.currentLevelCorrectWords).toContain('bear');
     });
 
+    it('is reachable via the Level Ended event (type 8), which the game sends as it reveals the board', async () => {
+      const wosWorker = findWorkerByUrlSubstring('wos-worker');
+      expect(wosWorker).toBeTruthy();
+
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      await wosWorker.emitMessage({
+        type: 'wos_event',
+        wosEventType: 8,
+        wosEventName: 'Level Ended',
+        username: '',
+        letters: [],
+        hitMax: false,
+        stars: 0,
+        level: 19,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: [{ index: 0, word: 'bear', user: 'mobileuser' }],
+        index: 0,
+      });
+
+      expect(spectator.currentLevelSlots[0].word).toBe('bear');
+      expect(spectator.currentLevelCorrectWords).not.toContain('????');
+      expect(spectator.currentLevelCorrectWords).toContain('bear');
+    });
+
+    it('stays a safe no-op for a real event-4 payload, which carries no slots', async () => {
+      // The event-4 payload captured in LIST.todo has stars/ranking/rankingTurn
+      // and no `slots`, so the worker normalizes it to []. Reconciliation must
+      // leave the masked slot alone rather than corrupting it.
+      spectator.isSoundsEnabled = false;
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      await (spectator as any).handleLevelResults(3, []);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('????');
+      expect(spectator.currentLevelSlots[0].user).toBe('mobileuser');
+    });
+
+    it('logs the masked slots that were never revealed (diagnostic)', () => {
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      (spectator as any).logUnresolvedMaskedSlots();
+
+      const gameLog = document.getElementById('wos-game-log')!.innerText;
+      expect(gameLog).toContain('1 hidden guess(es) never revealed');
+      expect(gameLog).toContain('mobileuser');
+    });
+
     it('does nothing when nothing usable is revealed', () => {
       spectator.currentLevelSlots = [
         { letters: [], word: '', hitMax: false, index: 0, length: 4 },

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -375,6 +375,86 @@ describe('GameSpectator class', () => {
     });
   });
 
+  describe('reconcileRevealedSlots (issue #143)', () => {
+    beforeEach(() => {
+      spectator = new GameSpectator();
+    });
+
+    it('backfills a masked slot with the revealed word and drops the placeholder', () => {
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+        { letters: [], word: '', hitMax: false, index: 1, length: 5 },
+      ];
+      // Slot 0 recorded as a masked mobile guess; slot 1 solved from chat.
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+      (spectator as any).updateCurrentLevelSlots('chatuser', ['b', 'e', 'a', 'r', 'd'], 1, false);
+      (spectator as any).updateCorrectWordsDisplayed('beard');
+
+      // The game reveals the full board before the level ends.
+      (spectator as any).reconcileRevealedSlots([
+        { index: 0, word: 'bear', user: 'mobileuser' },
+        { index: 1, word: 'beard', user: 'chatuser' },
+      ]);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('bear');
+      expect(spectator.currentLevelSlots[0].user).toBe('mobileuser');
+      expect(spectator.currentLevelCorrectWords).not.toContain('????');
+      expect(spectator.currentLevelCorrectWords).toContain('bear');
+    });
+
+    it('leaves genuinely-unsolved (missed) slots untouched', () => {
+      spectator.currentLevelSlots = [
+        { letters: ['.', '.', '.', '.'], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+
+      (spectator as any).reconcileRevealedSlots([{ index: 0, word: 'miss' }]);
+
+      // The slot was empty (not masked), so it must stay empty for missed-word
+      // detection rather than being filled from the reveal.
+      expect(spectator.currentLevelSlots[0].user).toBeUndefined();
+      expect(spectator.currentLevelSlots[0].word).toBe('');
+      expect(spectator.currentLevelCorrectWords).not.toContain('miss');
+    });
+
+    it('never overwrites an already-resolved real word', () => {
+      spectator.currentLevelSlots = [
+        { letters: ['t', 'e', 's', 't'], word: 'test', user: 'chatuser', hitMax: false, index: 0, length: 4 },
+      ];
+
+      (spectator as any).reconcileRevealedSlots([{ index: 0, word: 'best', user: 'x' }]);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('test');
+      expect(spectator.currentLevelSlots[0].user).toBe('chatuser');
+    });
+
+    it('reads the revealed word from a slot letters array when word is absent', () => {
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      (spectator as any).reconcileRevealedSlots([{ index: 0, letters: ['b', 'e', 'a', 'r'] }]);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('bear');
+      expect(spectator.currentLevelCorrectWords).toContain('bear');
+    });
+
+    it('does nothing when nothing usable is revealed', () => {
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      (spectator as any).reconcileRevealedSlots([]);
+      (spectator as any).reconcileRevealedSlots(undefined);
+      (spectator as any).reconcileRevealedSlots([{ index: 0, word: '????' }]);
+
+      // Still masked because nothing real was revealed for the slot.
+      expect(spectator.currentLevelSlots[0].word).toBe('????');
+      expect(spectator.currentLevelCorrectWords).toContain('????');
+    });
+  });
+
   describe('updateCorrectWordsDisplayed', () => {
     beforeEach(() => {
       spectator = new GameSpectator();
@@ -909,6 +989,21 @@ describe('GameSpectator class', () => {
 
       expect(document.getElementById('level-title')!.innerText).toBe('NEXT LEVEL');
       expect(document.getElementById('level-value')!.innerText).toBe('13');
+    });
+
+    it('should reveal masked hidden guesses from the level-results slots (issue #143)', async () => {
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+      ];
+      // A mobile player solved slot 0 with a word we couldn't recover.
+      (spectator as any).recordUnknownHiddenGuess('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      // Level results carry the revealed board words.
+      await (spectator as any).handleLevelResults(3, [{ index: 0, word: 'bear', user: 'mobileuser' }]);
+
+      expect(spectator.currentLevelSlots[0].word).toBe('bear');
+      expect(spectator.currentLevelCorrectWords).not.toContain('????');
+      expect(spectator.currentLevelCorrectWords).toContain('bear');
     });
   });
 
@@ -1589,6 +1684,25 @@ describe('GameSpectator class', () => {
       (spectator as any).updateGameState('chatuser', ['t', 'e', 's', 't'], 1, false);
 
       expect(document.getElementById('hidden-letter')!.innerText).not.toContain('?');
+    });
+
+    it('should replace a masked hidden guess with the real word once it is revealed (issue #143)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+      // A mobile player's hidden guess is first recorded masked.
+      (spectator as any).updateGameState('mobileuser', ['?', '?', '?', '?'], 0, false);
+      expect(spectator.currentLevelCorrectWords).toContain('????');
+
+      // WoS reveals the real word for that same slot (a non-masked event 3).
+      (spectator as any).updateGameState('mobileuser', ['b', 'e', 'a', 'r'], 0, false);
+
+      // The placeholder is replaced by the real word — no leftover '????' and
+      // no duplicate entry.
+      expect(spectator.currentLevelCorrectWords).not.toContain('????');
+      expect(spectator.currentLevelCorrectWords.filter(w => w === 'bear')).toHaveLength(1);
+      expect(spectator.currentLevelSlots[0].word).toBe('bear');
+      expect(spectator.currentLevelSlots[0].user).toBe('mobileuser');
+      warnSpy.mockRestore();
     });
 
     it('should capture a non-hidden guess directly from letters without any chat message (issue #96)', () => {

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -1492,16 +1492,103 @@ describe('GameSpectator class', () => {
       expect(spectator.currentLevelCorrectWords).toContain('test');
     });
 
-    it('should return early only for a hidden word with no matching message', () => {
+    it('should record an unresolvable hidden guess as solved with the word masked (issue #143)', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
 
-      // A masked word that cannot be resolved from chat is the only case that
-      // should be dropped — there is genuinely no way to know the word.
-      (spectator as any).updateGameState('testuser', ['?', '?', '?', '?'], 0, false);
+      // Mobile players guess in the WoS app, not Twitch chat, so their level-19+
+      // hidden guesses can't be reconstructed. Rather than dropping the guess
+      // (which made the slot read as *missed* at level end), it is recorded as
+      // solved by the user with the word left masked.
+      (spectator as any).updateGameState('mobileuser', ['?', '?', '?', '?'], 0, false);
 
       expect(warnSpy).toHaveBeenCalled();
-      expect(spectator.currentLevelCorrectWords).toEqual([]);
+      // The slot is marked solved so it's excluded from missed/empty-word tallies.
+      expect(spectator.currentLevelSlots[0].user).toBe('mobileuser');
+      // A masked placeholder is shown but never mistaken for a real word.
+      expect(spectator.currentLevelCorrectWords).toContain('????');
+
+      // It renders as a distinct hidden-word chip (not a plain correct word and
+      // not a missed word).
+      const chip = document
+        .getElementById('correct-words-log')!
+        .querySelector('.correct-word');
+      expect(chip).not.toBeNull();
+      expect(chip!.classList.contains('hidden-word')).toBe(true);
+      expect(chip!.classList.contains('missing-word')).toBe(false);
+      expect(chip!.textContent).toBe('????');
       warnSpy.mockRestore();
+    });
+
+    it('should keep an unresolvable hidden guess out of the empty-slot tally (issue #143)', () => {
+      // Seeded slots carry per-tile placeholders; logEmptySlots tallies by
+      // slot.letters.length.
+      spectator.currentLevelSlots = [
+        { letters: ['.', '.', '.', '.'], word: '', hitMax: false, index: 0, length: 4 },
+        { letters: ['.', '.', '.', '.', '.'], word: '', hitMax: false, index: 1, length: 5 },
+      ];
+
+      // A mobile player solves slot 0 with a hidden word we can't recover.
+      (spectator as any).updateGameState('mobileuser', ['?', '?', '?', '?'], 0, false);
+
+      (spectator as any).logEmptySlots();
+
+      // Slot 0 is solved (masked) and must not be counted as empty; only the
+      // genuinely-unsolved slot 1 (5 letters) remains.
+      expect(spectator.currentLevelEmptySlotsCount[4]).toBeUndefined();
+      expect(spectator.currentLevelEmptySlotsCount[5]).toBe(1);
+    });
+
+    it('should not treat a masked hidden guess as a missed word against the board (issue #143)', async () => {
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      const findMissingWordsFromBoardMock = vi.mocked(wosWords.findMissingWordsFromBoard);
+      // Delegate to the real implementation to exercise the slot.user exclusion.
+      const actual = await vi.importActual<typeof import('@scripts/wos-words')>('@scripts/wos-words');
+      findMissingWordsFromBoardMock.mockImplementation(actual.findMissingWordsFromBoard);
+
+      spectator.currentLevelBigWord = 'B E A R D';
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+        { letters: [], word: '', hitMax: false, index: 1, length: 5 },
+      ];
+
+      // Slot 0 solved by a mobile player (masked); slot 1 solved from chat.
+      (spectator as any).updateGameState('mobileuser', ['?', '?', '?', '?'], 0, false);
+      (spectator as any).updateGameState('chatuser', ['b', 'e', 'a', 'r', 'd'], 1, false);
+
+      fetchBoardMock.mockResolvedValueOnce({
+        id: 'BEARD',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [
+          { letters: ['b', 'e', 'a', 'r'], word: 'bear', hitMax: false },
+          { letters: ['b', 'e', 'a', 'r', 'd'], word: 'beard', hitMax: false },
+        ],
+      });
+
+      await (spectator as any).logMissingWords();
+
+      // The board's 4-letter word ('bear') sits at the index a mobile player
+      // solved, so it must NOT be reported as missed even though we don't know
+      // the exact word they typed.
+      expect(spectator.currentLevelCorrectWords).not.toContain('bear*');
+    });
+
+    it('should not let a masked hidden guess corrupt hidden-letter detection (issue #143)', () => {
+      // Level letters include a '?' slot so a spurious '?' hidden letter would
+      // actually surface in the display if the masked entry weren't skipped.
+      spectator.currentLevelLetters = ['t', 'e', 's', '?'];
+      spectator.currentLevelSlots = [
+        { letters: [], word: '', hitMax: false, index: 0, length: 4 },
+        { letters: [], word: '', hitMax: false, index: 1, length: 4 },
+      ];
+
+      // An earlier unresolved mobile hidden guess adds a '????' placeholder.
+      (spectator as any).updateGameState('mobileuser', ['?', '?', '?', '?'], 0, false);
+      // A later resolvable guess triggers hidden-letter frequency inference; the
+      // '????' placeholder must be ignored so '?' is never inferred as hidden.
+      (spectator as any).updateGameState('chatuser', ['t', 'e', 's', 't'], 1, false);
+
+      expect(document.getElementById('hidden-letter')!.innerText).not.toContain('?');
     });
 
     it('should capture a non-hidden guess directly from letters without any chat message (issue #96)', () => {


### PR DESCRIPTION
## What & why

Toward issue #143 (capturing mobile players' guesses). Mobile players submit guesses in the WoS app (`play.wos.gg`) rather than Twitch chat, so on **hidden levels (19+)** their masked correct-guess events have no chat message to reconstruct the word from.

### 1. Record unrecoverable hidden mobile guesses as solved, not missed
The spectator used to **drop** these guesses, leaving the slot reading as a **missed** word at level end even though it was solved. Now the guess is recorded as **solved by the user, word masked**, so the missed/empty-word tallies stay honest.

- **`recordUnknownHiddenGuess()`**: marks the slot with `slot.user` set (so it drops out of `logEmptySlots` and `findMissingWordsFromBoard`, which key off `slot.user`) and shows a masked placeholder chip. The masked slot never reaches the boards table — `saveBoard` rejects any `?`-bearing slot on two independent guards (the `isMissingWords` check and the `boardId` `/^[A-Z]+$/` validation), so saved board data can't be corrupted.
- Guards the hidden-letter frequency inference so a `?` placeholder can't be mistaken for a hidden letter.
- Renders masked entries as a distinct `.hidden-word` chip (shared + sticker-pop theme) with a tooltip.

### 2. Backfill masked slots once the game reveals the words
When WoS reveals the board's words, any slot we only had as a masked `????` is updated with the real word.

- **`updateGameState`**: when a real word resolves a slot we'd recorded as masked, drop the obsolete `????` placeholder so the real word replaces it (no duplicate).
- **`reconcileRevealedSlots()`**: backfill masked slots from the game's board state. It **only** ever replaces a masked placeholder with a real word — real words and genuinely-unsolved (missed) slots are left untouched, so missed-word detection is unaffected.
- Wired into **event 8 (Level Ended)**, plus events 4 and 5. Reconciliation is idempotent and a no-op without usable slot data, so covering every plausible carrier is safe.

## Which event actually reveals the words — read this before merging

This is the one genuinely unverified part, and it's worth calling out:

- **Event 4 cannot be the carrier.** The event-4 payload captured in `LIST.todo` has `stars`/`ranking`/`rankingTurn` and **no `slots`**, so `wos-worker` normalizes it to `[]`.
- **Event 8 ("Level Ended")** is forwarded by the worker with its `slots` but was previously **not routed on the main thread at all** — it's the most likely carrier, and is now wired.
- **WoS may not send revealed words to spectators at all.** The strongest evidence: this tool needs a Supabase boards cache *and* a dictionary fallback to figure out missed words. If the socket handed over the answers, none of that machinery would be necessary.

Because of that, `logUnresolvedMaskedSlots()` reports any still-masked slots once a level is over. **One real level-19+ session with a mobile player will settle it** — either the chips fill in (reveal works) or the log names the unresolved slots (reveal never arrives, and Option A/B from the issue is the only route).

## Known limitation

When a hidden guess is never revealed and the board isn't cached in the DB, the exact word stays unknown, so the dictionary-fallback missed-word path may still list it — there's no text to exclude it by. The board-based path excludes it correctly via `slot.user`.

## Behavior change worth noting

A level where a mobile player's hidden word was unrecoverable now has every slot carrying a `user`, so it can satisfy the existing `currentLevelSlots.every(slot => slot.user)` clear condition (clear sound, board save attempt). That's the intended correction — the slot genuinely was solved — but it does mean such levels are now treated as clears where they previously weren't. Board saves remain safe via the `saveBoard` guards above.

## Testing

- `pnpm exec vitest run` — full suite passes (**284 passed**, 28 todo). Coverage added for: masked guess recorded as solved + rendered as a `hidden-word` chip; excluded from empty-slot tally and board-based missed detection; hidden-letter inference unaffected; placeholder replaced on a later real-word event 3; `reconcileRevealedSlots` backfills masked slots, leaves missed/real slots untouched, reads the word from either `word` or `letters`; reachable via event 8; a **no-op for a realistic slot-less event-4 payload**; and the diagnostic log.
- The event-8 test was negative-checked — disabling the route makes exactly that test fail, so it isn't a false positive.
- `pnpm build` succeeds; `.hidden-word` styles present in compiled player/streamer CSS. Typecheck clean.

## To manually verify

On a level 19+ board, when a mobile (app) player lands a correct word: the slot shows a distinct masked `????` chip during play instead of counting as missed. When the board is revealed, that chip should fill in with the actual word — and if it doesn't, the game log will name the unresolved slots.