### PR TITLE
Testing standards PR 2: worker unit tests and property-based tests

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -111,14 +111,6 @@
       "count": 2
     }
   },
-  "tests/unit/twitch-chat-worker.test.ts": {
-    "@typescript-eslint/no-unsafe-function-type": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unused-vars": {
-      "count": 2
-    }
-  },
   "tests/unit/wos-plus-main.test.ts": {
     "@typescript-eslint/restrict-plus-operands": {
       "count": 1

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:property": "vitest run tests/property"
   },
   "dependencies": {
     "@astrojs/cloudflare": "14.1.3",
@@ -28,6 +29,7 @@
     "@types/socket.io-client": "1.4.36",
     "@vitest/coverage-v8": "4.1.9",
     "@vitest/ui": "4.1.9",
+    "fast-check": "4.9.0",
     "happy-dom": "^20.9.0",
     "vitest": "4.1.9",
     "wrangler": "4.110.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:property": "vitest run tests/property"
   },
   "dependencies": {
     "@astrojs/cloudflare": "14.1.3",
@@ -34,6 +35,7 @@
     "@vitest/ui": "4.1.9",
     "eslint": "9.39.5",
     "eslint-plugin-astro": "1.3.1",
+    "fast-check": "4.9.0",
     "happy-dom": "^20.9.0",
     "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       eslint-plugin-astro:
         specifier: 1.3.1
         version: 1.3.1(eslint@9.39.5)
+      fast-check:
+        specifier: 4.9.0
+        version: 4.9.0
       happy-dom:
         specifier: ^20.9.0
         version: 20.10.6
@@ -1978,6 +1981,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2597,6 +2604,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5262,6 +5272,10 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -5830,6 +5844,8 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   queue-microtask@1.2.3: {}
 

--- a/tests/fixtures/wos-events/01-level-start.json
+++ b/tests/fixtures/wos-events/01-level-start.json
@@ -1,0 +1,13 @@
+{
+  "eventType": 1,
+  "data": {
+    "level": 3,
+    "letters": ["c", "a", "u", "t", "i", "o", "n"],
+    "slots": [
+      { "letters": [], "word": "", "hitMax": false, "index": 0, "length": 4 },
+      { "letters": [], "word": "", "hitMax": false, "index": 1, "length": 4 },
+      { "letters": [], "word": "", "hitMax": false, "index": 2, "length": 5 },
+      { "letters": [], "word": "", "hitMax": false, "index": 3, "length": 7 }
+    ]
+  }
+}

--- a/tests/fixtures/wos-events/02-unknown-unhandled.json
+++ b/tests/fixtures/wos-events/02-unknown-unhandled.json
@@ -1,0 +1,4 @@
+{
+  "eventType": 2,
+  "data": {}
+}

--- a/tests/fixtures/wos-events/03-correct-guess-hidden.json
+++ b/tests/fixtures/wos-events/03-correct-guess-hidden.json
@@ -1,0 +1,9 @@
+{
+  "eventType": 3,
+  "data": {
+    "user": { "name": "Clarkio" },
+    "letters": ["c", "?", "u", "t", "i", "o", "n"],
+    "index": 3,
+    "hitMax": true
+  }
+}

--- a/tests/fixtures/wos-events/03-correct-guess-hidden.json
+++ b/tests/fixtures/wos-events/03-correct-guess-hidden.json
@@ -2,7 +2,7 @@
   "eventType": 3,
   "data": {
     "user": { "name": "Clarkio" },
-    "letters": ["c", "?", "u", "t", "i", "o", "n"],
+    "letters": ["?", "?", "?", "?", "?", "?", "?"],
     "index": 3,
     "hitMax": true
   }

--- a/tests/fixtures/wos-events/03-correct-guess.json
+++ b/tests/fixtures/wos-events/03-correct-guess.json
@@ -1,0 +1,9 @@
+{
+  "eventType": 3,
+  "data": {
+    "user": { "name": "SMC_May_I" },
+    "letters": ["c", "o", "a", "t"],
+    "index": 2,
+    "hitMax": false
+  }
+}

--- a/tests/fixtures/wos-events/04-level-results.json
+++ b/tests/fixtures/wos-events/04-level-results.json
@@ -1,0 +1,15 @@
+{
+  "eventType": 4,
+  "data": {
+    "stars": 5,
+    "ranking": [
+      { "user": { "id": "smc_may_i", "name": "smc_may_i" }, "points": 77 },
+      { "user": { "id": "ruggmattbot", "name": "RuggMattBot" }, "points": 61 },
+      { "user": { "id": "clarkio", "name": "Clarkio" }, "points": 16 }
+    ],
+    "rankingTurn": [
+      { "user": { "id": "smc_may_i", "name": "smc_may_i" }, "points": 18 },
+      { "user": { "id": "ruggmattbot", "name": "RuggMattBot" }, "points": 13 }
+    ]
+  }
+}

--- a/tests/fixtures/wos-events/05-game-ended.json
+++ b/tests/fixtures/wos-events/05-game-ended.json
@@ -1,0 +1,6 @@
+{
+  "eventType": 5,
+  "data": {
+    "level": 12
+  }
+}

--- a/tests/fixtures/wos-events/06-unknown-unhandled.json
+++ b/tests/fixtures/wos-events/06-unknown-unhandled.json
@@ -1,0 +1,4 @@
+{
+  "eventType": 6,
+  "data": {}
+}

--- a/tests/fixtures/wos-events/07-letters-cycled.json
+++ b/tests/fixtures/wos-events/07-letters-cycled.json
@@ -1,0 +1,6 @@
+{
+  "eventType": 7,
+  "data": {
+    "letters": ["n", "o", "i", "t", "u", "a", "c"]
+  }
+}

--- a/tests/fixtures/wos-events/08-level-ended.json
+++ b/tests/fixtures/wos-events/08-level-ended.json
@@ -1,0 +1,6 @@
+{
+  "eventType": 8,
+  "data": {
+    "level": 3
+  }
+}

--- a/tests/fixtures/wos-events/09-unknown-unhandled.json
+++ b/tests/fixtures/wos-events/09-unknown-unhandled.json
@@ -1,0 +1,4 @@
+{
+  "eventType": 9,
+  "data": {}
+}

--- a/tests/fixtures/wos-events/10-letters-revealed.json
+++ b/tests/fixtures/wos-events/10-letters-revealed.json
@@ -1,0 +1,7 @@
+{
+  "eventType": 10,
+  "data": {
+    "hiddenLetters": ["a"],
+    "falseLetters": ["x", "z"]
+  }
+}

--- a/tests/fixtures/wos-events/11-guessing-unlocked.json
+++ b/tests/fixtures/wos-events/11-guessing-unlocked.json
@@ -1,0 +1,4 @@
+{
+  "eventType": 11,
+  "data": {}
+}

--- a/tests/fixtures/wos-events/12-game-connected.json
+++ b/tests/fixtures/wos-events/12-game-connected.json
@@ -1,0 +1,14 @@
+{
+  "eventType": 12,
+  "data": {
+    "level": 7,
+    "record": 21,
+    "language": 2,
+    "letters": ["r", "e", "a", "l", "i", "t", "y"],
+    "slots": [
+      { "letters": ["t", "a", "l", "e"], "word": "tale", "user": "biocow", "hitMax": false, "index": 0, "length": 4 },
+      { "letters": [], "word": "", "hitMax": false, "index": 1, "length": 5 },
+      { "letters": [], "word": "", "hitMax": false, "index": 2, "length": 7 }
+    ]
+  }
+}

--- a/tests/fixtures/wos-events/README.md
+++ b/tests/fixtures/wos-events/README.md
@@ -24,6 +24,7 @@ before trusting any field as protocol truth.
 | `data.user.name` | **Known** | `wos-worker.ts` reads `data.user?.name`; the legacy handler kept in comments at the bottom of `wos-plus-main.ts` reads `data.user.name`. |
 | `data.letters` (array of single-character strings) | **Known** | `data.letters.join('')` / `data.letters.length` in the legacy handler; `letters.join(' ')` in `handleGameInitialization`. |
 | `'?'` placeholders inside `data.letters` | **Known** | `updateGameState()` branches on `word.includes('?')` for hidden words (level 19+), and `handleLetterReveal()` fills `'?'` slots. |
+| A hidden guess masks **every** letter | **Known (maintainer)** | Confirmed in review of PR #159. On a hidden correct-guess event the whole word is `'?'` — never a partial mask — so the length is all the event itself reveals. Partial masks only appear *later*, as `handleLetterReveal()` fills individual slots from event 10. `03-correct-guess-hidden.json` originally carried a partial mask, which was an invalid state. |
 | `data.hitMax` (boolean) | **Known** | `data.hitMax === true` in the legacy handler; drives big-word detection. |
 | `data.index` (number) | **Known** | Used as the slot index in `updateCurrentLevelSlots()`. |
 | `data.stars` (number) on event 4 | **Known** | `data.stars` in the legacy handler; a real recorded event-4 payload is quoted in `LIST.todo`. |

--- a/tests/fixtures/wos-events/README.md
+++ b/tests/fixtures/wos-events/README.md
@@ -1,0 +1,51 @@
+# WoS event fixtures
+
+Input payloads for `src/scripts/wos-worker.ts`, used by
+`tests/unit/wos-worker.test.ts`.
+
+Each file is exactly what `wos-plus-main.ts` posts into the worker for a WoS
+socket event:
+
+```ts
+this.wosSocket.on('3', (eventType, data) => wosWorker.postMessage({ eventType, data }));
+```
+
+so a fixture is `{ "eventType": <number>, "data": <socket payload> }`.
+
+## Provenance — what is known and what is inferred
+
+**These fixtures are not captured from a live socket session.** They were
+derived from the code that produces and consumes the payloads. Read the table
+before trusting any field as protocol truth.
+
+| Field | Status | Evidence |
+| --- | --- | --- |
+| `eventType` numbers 1, 3, 4, 5, 7, 8, 10, 11, 12 | **Known** | Branches in `wos-worker.ts`; names come from that file's `wosEventName` strings. |
+| `data.user.name` | **Known** | `wos-worker.ts` reads `data.user?.name`; the legacy handler kept in comments at the bottom of `wos-plus-main.ts` reads `data.user.name`. |
+| `data.letters` (array of single-character strings) | **Known** | `data.letters.join('')` / `data.letters.length` in the legacy handler; `letters.join(' ')` in `handleGameInitialization`. |
+| `'?'` placeholders inside `data.letters` | **Known** | `updateGameState()` branches on `word.includes('?')` for hidden words (level 19+), and `handleLetterReveal()` fills `'?'` slots. |
+| `data.hitMax` (boolean) | **Known** | `data.hitMax === true` in the legacy handler; drives big-word detection. |
+| `data.index` (number) | **Known** | Used as the slot index in `updateCurrentLevelSlots()`. |
+| `data.stars` (number) on event 4 | **Known** | `data.stars` in the legacy handler; a real recorded event-4 payload is quoted in `LIST.todo`. |
+| `data.ranking` / `data.rankingTurn` on event 4 | **Known (recorded)** | Copied — abridged to three entries — from the real event-4 payload recorded in `LIST.todo` lines 12–102. The worker drops both fields; the fixture keeps them to prove that. |
+| `data.level` (number) on events 1 and 12 | **Known** | `wos-worker.ts` asserts `data.level!` for both; `handleGameInitialization()` does `parseInt(level)`. |
+| `data.record` on event 12 | **Known** | `wos-worker.ts` only copies `data.record` onto the result for event 12. |
+| `data.language` (1 = pt, 2 = en, 4 = fr) | **Known** | Documented in `WosWorkerMessage` and mapped by `wosLanguageIdToCode()` in `src/lib/board-utils.ts`. |
+| `data.hiddenLetters` / `data.falseLetters` on event 10 | **Known** | Both read by `wos-worker.ts` and by `handleLetterReveal()`. |
+| `data.slots` **element shape** | **INFERRED** | The worker passes `slots` through untouched, so its shape is invisible to the worker. The fixtures use the `Slots` type declared in `wos-plus-main.ts` (`{ letters, word, user?, hitMax, index, length }`), which is also the shape the existing `wos-plus-main` tests use. Whether WoS itself sends exactly these keys (or, e.g., omits `word`/`user` for unguessed slots) is **not verified**. |
+| `data.level` on events 5 and 8 | **INFERRED** | Nothing reads `level` for these events. Included only so the fixtures aren't empty; the value is made up. |
+| `data.letters` on event 7 (Letters Cycled) | **INFERRED** | The name suggests a re-ordered letter set, and the worker copies `data.letters` for every event, but no consumer reads it for event 7. The specific array is made up. |
+| Event 11 (Guessing Unlocked) payload | **INFERRED** | Unknown; modelled as an empty object. Nothing in this repo reads any field of it. |
+| Event types **2, 6, 9** | **UNKNOWN** | `wos-worker.ts` has no branch for them and no code or documentation in this repo describes them. The `0N-unknown-unhandled.json` fixtures carry an empty `data` on purpose: rather than invent a payload, they only pin the contract the worker actually has for unhandled types — no `postMessage`, no throw. |
+
+`copilot-instructions.md` says the worker "processes 12 WoS event types". It in
+fact has explicit branches for **nine** types; the numbering runs 1–12 with 2,
+6 and 9 unhandled. The test table has a row for all twelve numbers so that
+distinction is visible at a glance.
+
+## Malformed input
+
+Malformed cases (null message, missing `data`, wrong types, empty payload) are
+built inline in `tests/unit/wos-worker.test.ts` rather than stored here — they
+are deliberately-broken inputs, not protocol samples, and keeping them in the
+test keeps the "what breaks" next to "what should happen".

--- a/tests/property/board-utils.property.test.ts
+++ b/tests/property/board-utils.property.test.ts
@@ -64,12 +64,12 @@ const anyChannelInputArb = fc.oneof(
   { weight: 4, arbitrary: channelishArb },
   { weight: 2, arbitrary: hashPrefixedChannelArb },
   { weight: 2, arbitrary: boundaryLengthChannelArb },
-  { weight: 2, arbitrary: fc.string({ maxLength: 60 }) as fc.Arbitrary<unknown> },
+  { weight: 2, arbitrary: fc.string({ maxLength: 60 }) },
   { weight: 1, arbitrary: fc.anything() },
 );
 
 const anyLanguageInputArb = fc.oneof(
-  { weight: 3, arbitrary: fc.constantFrom('en', 'pt', 'fr') as fc.Arbitrary<unknown> },
+  { weight: 3, arbitrary: fc.constantFrom('en', 'pt', 'fr') },
   {
     weight: 3,
     arbitrary: fc.constantFrom(
@@ -82,31 +82,32 @@ const anyLanguageInputArb = fc.oneof(
       'eng',
       '',
       '  '
-    ) as fc.Arbitrary<unknown>,
+    ),
   },
-  { weight: 2, arbitrary: fc.string({ maxLength: 8 }) as fc.Arbitrary<unknown> },
+  { weight: 2, arbitrary: fc.string({ maxLength: 8 }) },
   { weight: 1, arbitrary: fc.anything() },
 );
 
 const slotLikeArb = fc.record(
   {
     word: fc.oneof(fc.string({ maxLength: 8 }), fc.constant(undefined), fc.integer()),
-    letters: fc.array(fc.char(), { maxLength: 6 }),
+    // fast-check 4 removed fc.char(); a length-1 string is the replacement.
+    letters: fc.array(fc.string({ minLength: 1, maxLength: 1 }), { maxLength: 6 }),
     hitMax: fc.boolean(),
   },
   { requiredKeys: [] }
 );
 
 const anySlotsInputArb = fc.oneof(
-  { weight: 3, arbitrary: fc.array(slotLikeArb, { maxLength: 6 }) as fc.Arbitrary<unknown> },
+  { weight: 3, arbitrary: fc.array(slotLikeArb, { maxLength: 6 }) },
   {
     weight: 3,
     arbitrary: fc
       .array(slotLikeArb, { maxLength: 6 })
-      .map((slots) => JSON.stringify(slots)) as fc.Arbitrary<unknown>,
+      .map((slots) => JSON.stringify(slots)),
   },
-  { weight: 2, arbitrary: fc.json() as fc.Arbitrary<unknown> },
-  { weight: 2, arbitrary: fc.string({ maxLength: 40 }) as fc.Arbitrary<unknown> },
+  { weight: 2, arbitrary: fc.json() },
+  { weight: 2, arbitrary: fc.string({ maxLength: 40 }) },
   { weight: 2, arbitrary: fc.anything() },
 );
 

--- a/tests/property/board-utils.property.test.ts
+++ b/tests/property/board-utils.property.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  coerceSlots,
+  normalizeLanguageCode,
+  normalizeTwitchChannel,
+  WOS_LANGUAGE_ID_TO_CODE,
+} from '../../src/lib/board-utils';
+import { propertyRunConfig } from './fc-config';
+
+/**
+ * Property-based tests for the board data normalizers (issue #150, plan phase 4).
+ *
+ * These functions sit directly on the request path for saving a board, so they
+ * see genuinely arbitrary input. The invariants that matter are:
+ *
+ * - **Idempotence** (`f(f(x)) === f(x)`): the normalizers are also applied to
+ *   values that have already been stored, so a normalizer that keeps changing
+ *   its own output would let the same logical board be written two ways.
+ * - **Output alphabet**: whatever comes back must be safe to store, so the
+ *   non-null output has to match the character class the doc comment promises —
+ *   not merely "the examples we tried came out clean".
+ * - **Totality**: none of these may throw, whatever they are handed. They are
+ *   documented as never blocking a board from saving, and a thrown TypeError on
+ *   a weird payload would do exactly that.
+ */
+
+/** The alphabet `normalizeTwitchChannel` promises for its non-null output. */
+const TWITCH_CHANNEL_OUTPUT = /^[a-z0-9_]{1,50}$/;
+
+/** The only language codes `normalizeLanguageCode` may ever return. */
+const SUPPORTED_LANGUAGE_CODES = Object.values(WOS_LANGUAGE_ID_TO_CODE);
+
+const CHANNEL_CHARS =
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-#. \t\n'.split('');
+
+/** Strings that look like something a user would actually type as a channel. */
+const channelishArb = fc
+  .array(fc.constantFrom(...CHANNEL_CHARS), { maxLength: 60 })
+  .map((chars) => chars.join(''));
+
+/**
+ * Names straddling the documented 50-character limit. Random strings almost
+ * never land exactly on a boundary, so the boundary gets its own generator —
+ * an off-by-one in `{1,50}` is precisely the kind of mistake this suite exists
+ * to catch.
+ */
+const boundaryLengthChannelArb = fc
+  .integer({ min: 45, max: 55 })
+  .chain((length) =>
+    fc.array(fc.constantFrom(...'abcxyz019_'.split('')), {
+      minLength: length,
+      maxLength: length,
+    })
+  )
+  .map((chars) => chars.join(''));
+
+/** A '#'-prefixed channel, which is how Twitch itself names a chat room. */
+const hashPrefixedChannelArb = fc
+  .array(fc.constantFrom(...'abcdefgXYZ019_'.split('')), { minLength: 1, maxLength: 25 })
+  .map((chars) => `#${chars.join('')}`);
+
+const anyChannelInputArb = fc.oneof(
+  { weight: 4, arbitrary: channelishArb },
+  { weight: 2, arbitrary: hashPrefixedChannelArb },
+  { weight: 2, arbitrary: boundaryLengthChannelArb },
+  { weight: 2, arbitrary: fc.string({ maxLength: 60 }) as fc.Arbitrary<unknown> },
+  { weight: 1, arbitrary: fc.anything() },
+);
+
+const anyLanguageInputArb = fc.oneof(
+  { weight: 3, arbitrary: fc.constantFrom('en', 'pt', 'fr') as fc.Arbitrary<unknown> },
+  {
+    weight: 3,
+    arbitrary: fc.constantFrom(
+      'EN',
+      'Pt',
+      ' fr ',
+      '\tEN\n',
+      'en-US',
+      'de',
+      'eng',
+      '',
+      '  '
+    ) as fc.Arbitrary<unknown>,
+  },
+  { weight: 2, arbitrary: fc.string({ maxLength: 8 }) as fc.Arbitrary<unknown> },
+  { weight: 1, arbitrary: fc.anything() },
+);
+
+const slotLikeArb = fc.record(
+  {
+    word: fc.oneof(fc.string({ maxLength: 8 }), fc.constant(undefined), fc.integer()),
+    letters: fc.array(fc.char(), { maxLength: 6 }),
+    hitMax: fc.boolean(),
+  },
+  { requiredKeys: [] }
+);
+
+const anySlotsInputArb = fc.oneof(
+  { weight: 3, arbitrary: fc.array(slotLikeArb, { maxLength: 6 }) as fc.Arbitrary<unknown> },
+  {
+    weight: 3,
+    arbitrary: fc
+      .array(slotLikeArb, { maxLength: 6 })
+      .map((slots) => JSON.stringify(slots)) as fc.Arbitrary<unknown>,
+  },
+  { weight: 2, arbitrary: fc.json() as fc.Arbitrary<unknown> },
+  { weight: 2, arbitrary: fc.string({ maxLength: 40 }) as fc.Arbitrary<unknown> },
+  { weight: 2, arbitrary: fc.anything() },
+);
+
+describe('board-utils properties', () => {
+  describe('normalizeTwitchChannel', () => {
+    it('is idempotent: normalizing its own output changes nothing', () => {
+      fc.assert(
+        fc.property(anyChannelInputArb, (input) => {
+          const once = normalizeTwitchChannel(input);
+          expect(normalizeTwitchChannel(once)).toBe(once);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('only ever returns null or a lowercase [a-z0-9_] name of 1..50 characters', () => {
+      fc.assert(
+        fc.property(anyChannelInputArb, (input) => {
+          const result = normalizeTwitchChannel(input);
+          if (result !== null) {
+            expect(result).toMatch(TWITCH_CHANNEL_OUTPUT);
+            expect(result).toBe(result.toLowerCase());
+            expect(result.length).toBeLessThanOrEqual(50);
+            expect(result.length).toBeGreaterThan(0);
+          }
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('never throws, whatever it is handed', () => {
+      fc.assert(
+        fc.property(fc.anything(), (input) => {
+          expect(() => normalizeTwitchChannel(input)).not.toThrow();
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('accepts a valid name at or below the 50-character limit and rejects it above', () => {
+      fc.assert(
+        fc.property(boundaryLengthChannelArb, (name) => {
+          const accepted = normalizeTwitchChannel(name) !== null;
+          expect(accepted).toBe(name.length <= 50);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('treats a leading "#", surrounding whitespace and casing as noise on an otherwise valid name', () => {
+      fc.assert(
+        fc.property(
+          fc
+            .array(fc.constantFrom(...'abcdefgXYZ019_'.split('')), {
+              minLength: 1,
+              maxLength: 40,
+            })
+            .map((chars) => chars.join('')),
+          fc.constantFrom('', '#'),
+          fc.constantFrom('', ' ', '  ', '\t', '\n'),
+          (name, hash, space) => {
+            expect(normalizeTwitchChannel(`${space}${hash}${name}${space}`)).toBe(
+              name.toLowerCase()
+            );
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+  });
+
+  describe('normalizeLanguageCode', () => {
+    it('is idempotent: normalizing its own output changes nothing', () => {
+      fc.assert(
+        fc.property(anyLanguageInputArb, (input) => {
+          const once = normalizeLanguageCode(input);
+          expect(normalizeLanguageCode(once)).toBe(once);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('only ever returns null or one of the three supported lowercase codes', () => {
+      fc.assert(
+        fc.property(anyLanguageInputArb, (input) => {
+          const result = normalizeLanguageCode(input);
+          if (result !== null) {
+            expect(SUPPORTED_LANGUAGE_CODES).toContain(result);
+            expect(result).toMatch(/^[a-z]{2}$/);
+          }
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('never throws, whatever it is handed', () => {
+      fc.assert(
+        fc.property(fc.anything(), (input) => {
+          expect(() => normalizeLanguageCode(input)).not.toThrow();
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('recovers a supported code through any casing and surrounding whitespace', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom(...SUPPORTED_LANGUAGE_CODES),
+          fc.constantFrom('', ' ', '\t', '\n  '),
+          fc.boolean(),
+          (code, space, upper) => {
+            const raw = `${space}${upper ? code.toUpperCase() : code}${space}`;
+            expect(normalizeLanguageCode(raw)).toBe(code);
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+  });
+
+  describe('coerceSlots', () => {
+    it('never throws, whatever it is handed', () => {
+      fc.assert(
+        fc.property(anySlotsInputArb, (input) => {
+          expect(() => coerceSlots(input)).not.toThrow();
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('always produces a valid shape: null or an array', () => {
+      fc.assert(
+        fc.property(anySlotsInputArb, (input) => {
+          const result = coerceSlots(input);
+          expect(result === null || Array.isArray(result)).toBe(true);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('is idempotent: coercing its own output changes nothing', () => {
+      fc.assert(
+        fc.property(anySlotsInputArb, (input) => {
+          const once = coerceSlots(input);
+          expect(coerceSlots(once)).toBe(once);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('passes arrays through untouched', () => {
+      fc.assert(
+        fc.property(fc.array(slotLikeArb, { maxLength: 6 }), (slots) => {
+          expect(coerceSlots(slots)).toBe(slots);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('parses the JSON-string form of an array back to an equivalent array', () => {
+      fc.assert(
+        fc.property(fc.array(slotLikeArb, { maxLength: 6 }), (slots) => {
+          const result = coerceSlots(JSON.stringify(slots));
+          expect(Array.isArray(result)).toBe(true);
+          expect(result).toHaveLength(slots.length);
+          expect(result).toEqual(JSON.parse(JSON.stringify(slots)));
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('returns null for any JSON value that is not an array', () => {
+      fc.assert(
+        fc.property(
+          fc.jsonValue().filter((value) => !Array.isArray(value)),
+          (value) => {
+            expect(coerceSlots(JSON.stringify(value))).toBeNull();
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+  });
+});

--- a/tests/property/fc-config.ts
+++ b/tests/property/fc-config.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared fast-check run configuration for the property suites (issue #150).
+ *
+ * Two things matter here and both are deliberate:
+ *
+ * 1. **Explicit seed.** Property tests generate their inputs, so an unseeded
+ *    run that fails once may pass on the next CI attempt. Pinning the seed
+ *    makes every failure reproducible locally with the exact same inputs. When
+ *    a counterexample *is* found it also gets pinned as a plain example-based
+ *    regression test next to the property, so the regression stays caught even
+ *    if the seed ever changes.
+ * 2. **Bounded run count.** These run as part of the ordinary `vitest run`, so
+ *    they have to stay fast. A few hundred cases per property is enough to
+ *    surface the off-by-one / inverted-condition / boundary mistakes these
+ *    tests exist to catch, without turning the unit suite into a soak test.
+ *
+ * To reproduce a reported failure, fast-check prints the seed and path; run
+ * `pnpm run test:property` after temporarily setting `seed` to the reported
+ * value.
+ */
+
+/** Single seed shared by every property so failures are reproducible. */
+export const PROPERTY_SEED = 20260724;
+
+/** Default parameters passed to every `fc.assert` call in tests/property. */
+export const propertyRunConfig = {
+  seed: PROPERTY_SEED,
+  numRuns: 200,
+} as const;
+
+/** Same seed, fewer runs — for properties whose inputs are expensive to build. */
+export const shortPropertyRunConfig = {
+  seed: PROPERTY_SEED,
+  numRuns: 100,
+} as const;

--- a/tests/property/mirror-url.property.test.ts
+++ b/tests/property/mirror-url.property.test.ts
@@ -40,6 +40,8 @@ function looksLikeGameId(value: string): boolean {
   return segments.every(
     (segment, index) =>
       segment.length === GAME_ID_SEGMENT_LENGTHS[index] &&
+      // UUID segments are hex ASCII by construction; no surrogate pairs.
+      // eslint-disable-next-line @typescript-eslint/no-misused-spread
       [...segment].every((char) => HEX_DIGITS.includes(char))
   );
 }

--- a/tests/property/mirror-url.property.test.ts
+++ b/tests/property/mirror-url.property.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  getMirrorGameId,
+  isValidGameId,
+  normalizeMirrorUrl,
+  WOS_MIRROR_BASE,
+} from '@scripts/mirror-url';
+import { propertyRunConfig } from './fc-config';
+
+/**
+ * Property-based tests for the mirror URL parser (issue #150, plan phase 4).
+ *
+ * `normalizeMirrorUrl` / `getMirrorGameId` are an encode/decode pair, which is
+ * the classic shape for a round-trip property: whatever id goes in must come
+ * back out unchanged. Example tests here would only ever check the handful of
+ * ids somebody thought to type; the round-trip property checks it for hundreds
+ * of generated UUIDs, and the totality properties check that *no* input — valid
+ * URL, hostile URL, or arbitrary junk — can make these functions return
+ * something that isn't a real game id.
+ */
+
+/**
+ * Independent structural check for "is this a WoS game id".
+ *
+ * Deliberately NOT the production regex (and not imported from the module under
+ * test) — it is written as an explicit segment/length/hex-digit walk so that a
+ * mistake in `GAME_ID_PATTERN` (a wrong segment length, a missing anchor, a
+ * character class that leaks non-hex characters) shows up as a disagreement
+ * instead of being silently mirrored by the test.
+ */
+const HEX_DIGITS = '0123456789abcdefABCDEF';
+const GAME_ID_SEGMENT_LENGTHS = [8, 4, 4, 4, 12];
+
+function looksLikeGameId(value: string): boolean {
+  const segments = value.trim().split('-');
+  if (segments.length !== GAME_ID_SEGMENT_LENGTHS.length) {
+    return false;
+  }
+  return segments.every(
+    (segment, index) =>
+      segment.length === GAME_ID_SEGMENT_LENGTHS[index] &&
+      [...segment].every((char) => HEX_DIGITS.includes(char))
+  );
+}
+
+/** Game ids as they really appear: lowercase UUIDs, plus the uppercase variant. */
+const gameIdArb = fc.oneof(
+  fc.uuid(),
+  fc.uuid().map((id) => id.toUpperCase()),
+);
+
+/**
+ * Inputs that are *not* bare game ids: random text, unrelated URLs, and the
+ * near-miss URLs an attacker or a typo would produce (wrong scheme, wrong host,
+ * lookalike host, wrong path, extra path segment).
+ */
+const nonGameIdArb = fc.oneof(
+  fc.string(),
+  fc.string({ maxLength: 80 }),
+  fc.webUrl(),
+  fc.uuid().map((id) => `https://example.com/r/${id}`),
+  fc.uuid().map((id) => `http://wos.gg/r/${id}`),
+  fc.uuid().map((id) => `https://evil-wos.gg/r/${id}`),
+  fc.uuid().map((id) => `https://wos.gg.attacker.test/r/${id}`),
+  fc.uuid().map((id) => `https://wos.gg/x/${id}`),
+  fc.uuid().map((id) => `https://wos.gg/r/${id}/extra`),
+  fc.uuid().map((id) => id.slice(0, -1)),
+  fc.uuid().map((id) => `${id}${id}`),
+);
+
+/** Anything at all that could reach these functions from a form field. */
+const anyInputArb = fc.oneof(
+  gameIdArb,
+  nonGameIdArb,
+  gameIdArb.map((id) => `${WOS_MIRROR_BASE}${id}`),
+  gameIdArb.map((id) => `  ${WOS_MIRROR_BASE}${id}  `),
+  gameIdArb.map((id) => `  ${id}\n`),
+  gameIdArb.map((id) => `${WOS_MIRROR_BASE}${id}?spectate=1#top`),
+);
+
+describe('mirror-url properties', () => {
+  describe('normalizeMirrorUrl / getMirrorGameId round-trip', () => {
+    it('recovers the exact game id from the URL it was normalized into', () => {
+      fc.assert(
+        fc.property(gameIdArb, (gameId) => {
+          const url = normalizeMirrorUrl(gameId);
+          expect(url).not.toBeNull();
+          expect(getMirrorGameId(url as string)).toBe(gameId);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('normalizes a bare game id to exactly the canonical mirror URL', () => {
+      fc.assert(
+        fc.property(gameIdArb, (gameId) => {
+          expect(normalizeMirrorUrl(gameId)).toBe(`${WOS_MIRROR_BASE}${gameId}`);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('recovers the game id whether the URL or the bare id was pasted, including with surrounding whitespace', () => {
+      fc.assert(
+        fc.property(
+          gameIdArb,
+          fc.constantFrom('', ' ', '  ', '\n', '\t '),
+          fc.constantFrom('', ' ', '\n'),
+          (gameId, before, after) => {
+            expect(getMirrorGameId(`${before}${gameId}${after}`)).toBe(gameId);
+            expect(
+              getMirrorGameId(`${before}${WOS_MIRROR_BASE}${gameId}${after}`)
+            ).toBe(gameId);
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+
+    it('is idempotent: normalizing an already-canonical URL changes nothing', () => {
+      fc.assert(
+        fc.property(anyInputArb, (input) => {
+          const once = normalizeMirrorUrl(input);
+          const twice = once === null ? null : normalizeMirrorUrl(once);
+          expect(twice).toBe(once);
+        }),
+        propertyRunConfig
+      );
+    });
+  });
+
+  describe('isValidGameId agrees with an independent game-id check', () => {
+    it('accepts every generated UUID', () => {
+      fc.assert(
+        fc.property(gameIdArb, (gameId) => {
+          expect(looksLikeGameId(gameId)).toBe(true);
+          expect(isValidGameId(gameId)).toBe(true);
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('rejects arbitrary strings that are not game ids', () => {
+      fc.assert(
+        fc.property(
+          nonGameIdArb.filter((value) => !looksLikeGameId(value)),
+          (value) => {
+            expect(isValidGameId(value)).toBe(false);
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+
+    it('agrees with the independent check on completely arbitrary input', () => {
+      fc.assert(
+        fc.property(anyInputArb, (value) => {
+          expect(isValidGameId(value)).toBe(looksLikeGameId(value));
+        }),
+        propertyRunConfig
+      );
+    });
+  });
+
+  describe('totality: no input produces a non-game-id result', () => {
+    it('getMirrorGameId returns null or a genuine game id, never anything else', () => {
+      fc.assert(
+        fc.property(anyInputArb, (input) => {
+          const result = getMirrorGameId(input);
+          if (result !== null) {
+            expect(looksLikeGameId(result)).toBe(true);
+            expect(result.trim()).toBe(result);
+          }
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('normalizeMirrorUrl returns null or a canonical wos.gg URL, never anything else', () => {
+      fc.assert(
+        fc.property(anyInputArb, (input) => {
+          const result = normalizeMirrorUrl(input);
+          if (result !== null) {
+            expect(result.startsWith(WOS_MIRROR_BASE)).toBe(true);
+            expect(looksLikeGameId(result.slice(WOS_MIRROR_BASE.length))).toBe(true);
+          }
+        }),
+        propertyRunConfig
+      );
+    });
+
+    it('never returns a game id for a host other than wos.gg', () => {
+      fc.assert(
+        fc.property(
+          fc.uuid(),
+          fc.constantFrom(
+            'example.com',
+            'evil-wos.gg',
+            'wos.gg.attacker.test',
+            'wosplus.com',
+            'wos.gg.co'
+          ),
+          (gameId, host) => {
+            expect(getMirrorGameId(`https://${host}/r/${gameId}`)).toBeNull();
+          }
+        ),
+        propertyRunConfig
+      );
+    });
+  });
+});

--- a/tests/property/wos-words.property.test.ts
+++ b/tests/property/wos-words.property.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fc from 'fast-check';
+import { propertyRunConfig } from './fc-config';
+
+/**
+ * Property-based tests for the word-matching engine (issue #150).
+ *
+ * Example-based tests assert on hand-picked inputs, which an implementation can
+ * satisfy without being correct — and which an agent can overfit to. These
+ * assert *invariants* over generated input instead, which is what catches the
+ * off-by-one / inverted-condition / boundary mistakes example tests miss.
+ *
+ * `findWosWordsByLetters` is module-private; it is reached through
+ * `findAllMissingWords`, the only path the application uses.
+ */
+
+type WosWordsModule = typeof import('@scripts/wos-words');
+
+/** Letters chosen so many short words are formable from small subsets. */
+const LETTER_POOL = 'aeiorstn';
+
+/**
+ * A fixed dictionary. Deliberately includes words needing doubled letters
+ * ('tree', 'treat', 'sees') so the letter-frequency accounting is exercised
+ * rather than mere letter-membership.
+ */
+const DICTIONARY = [
+  'rate', 'tear', 'tare', 'star', 'rats', 'tars', 'oats', 'oars', 'soar',
+  'note', 'tone', 'tore', 'rote', 'stone', 'stoner', 'tenor', 'snore',
+  'tree', 'treat', 'sees', 'irate', 'ratio', 'ration', 'nitro', 'intro',
+  'rain', 'train', 'strain', 'saint', 'stain', 'satin', 'antis',
+];
+
+/**
+ * Independent re-implementation of "can this word be built from these letters",
+ * written from the rules rather than from the production helper. Importing the
+ * production check here would make every property below tautological.
+ */
+function isBuildableFrom(word: string, letters: string): boolean {
+  const available = new Map<string, number>();
+  for (const ch of letters.toLowerCase()) {
+    available.set(ch, (available.get(ch) ?? 0) + 1);
+  }
+  for (const ch of word.toLowerCase()) {
+    const remaining = available.get(ch) ?? 0;
+    if (remaining === 0) return false;
+    available.set(ch, remaining - 1);
+  }
+  return true;
+}
+
+/** Loads a fresh module instance with DICTIONARY installed via the real load path. */
+async function loadModuleWithDictionary(): Promise<WosWordsModule> {
+  vi.resetModules();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => DICTIONARY,
+  }));
+  vi.spyOn(console, 'log').mockImplementation(() => { });
+  vi.spyOn(console, 'error').mockImplementation(() => { });
+
+  const wosWords = await import('@scripts/wos-words');
+  await wosWords.loadWordsFromDb();
+  return wosWords;
+}
+
+/** Arbitrary for a bag of letters drawn from the pool. */
+const lettersArb = fc
+  .array(fc.constantFrom(...LETTER_POOL.split('')), { minLength: 4, maxLength: 8 })
+  .map(chars => chars.join(''));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('findAllMissingWords / findWosWordsByLetters properties', () => {
+  it('only returns words that can actually be built from the given letters', async () => {
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(lettersArb, fc.integer({ min: 4, max: 6 }), async (letters, minLength) => {
+        const missing = wosWords.findAllMissingWords([], letters, minLength);
+        for (const word of missing) {
+          expect(isBuildableFrom(word, letters)).toBe(true);
+        }
+      }),
+      propertyRunConfig,
+    );
+  });
+
+  it('only returns words that are in the dictionary', async () => {
+    const wosWords = await loadModuleWithDictionary();
+    const known = new Set(DICTIONARY.map(w => w.toLowerCase()));
+
+    await fc.assert(
+      fc.asyncProperty(lettersArb, async letters => {
+        for (const word of wosWords.findAllMissingWords([], letters, 4)) {
+          expect(known.has(word.toLowerCase())).toBe(true);
+        }
+      }),
+      propertyRunConfig,
+    );
+  });
+
+  it('is invariant under permutation of the input letters', async () => {
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(lettersArb, async letters => {
+        // Letters come from an ASCII pool by construction; no surrogate pairs.
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread
+        const shuffled = [...letters].reverse().join('');
+        const a = [...wosWords.findAllMissingWords([], letters, 4)].sort();
+        const b = [...wosWords.findAllMissingWords([], shuffled, 4)].sort();
+        expect(b).toEqual(a);
+      }),
+      propertyRunConfig,
+    );
+  });
+
+  it('never loses a word when another letter is added (monotonicity)', async () => {
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(
+        lettersArb,
+        fc.constantFrom(...LETTER_POOL.split('')),
+        async (letters, extra) => {
+          const before = wosWords.findAllMissingWords([], letters, 4);
+          const after = new Set(wosWords.findAllMissingWords([], letters + extra, 4));
+          for (const word of before) {
+            expect(after.has(word)).toBe(true);
+          }
+        },
+      ),
+      propertyRunConfig,
+    );
+  });
+
+  it('never returns a word shorter than minLength', async () => {
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(lettersArb, fc.integer({ min: 4, max: 8 }), async (letters, minLength) => {
+        for (const word of wosWords.findAllMissingWords([], letters, minLength)) {
+          expect(word.length).toBeGreaterThanOrEqual(minLength);
+        }
+      }),
+      propertyRunConfig,
+    );
+  });
+
+  it('never returns a word that is already known', async () => {
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(
+        lettersArb,
+        fc.subarray(DICTIONARY, { maxLength: 5 }),
+        async (letters, known) => {
+          const missing = wosWords.findAllMissingWords(known, letters, 4);
+          for (const word of known) {
+            expect(missing).not.toContain(word.toLowerCase());
+          }
+        },
+      ),
+      propertyRunConfig,
+    );
+  });
+
+  it('never returns a known word that carries the * missed-word marker', async () => {
+    // The UI appends '*' to missed words and pushes them back into the same
+    // list that is later passed as knownWords, so the marker has to be stripped
+    // before comparison or the word is re-reported on every subsequent run.
+    const wosWords = await loadModuleWithDictionary();
+
+    await fc.assert(
+      fc.asyncProperty(
+        lettersArb,
+        fc.subarray(DICTIONARY, { maxLength: 5 }),
+        async (letters, known) => {
+          const marked = known.map(w => `${w}*`);
+          const missing = wosWords.findAllMissingWords(marked, letters, 4);
+          for (const word of known) {
+            expect(missing).not.toContain(word.toLowerCase());
+          }
+        },
+      ),
+      propertyRunConfig,
+    );
+  });
+});

--- a/tests/unit/twitch-chat-worker.test.ts
+++ b/tests/unit/twitch-chat-worker.test.ts
@@ -1,456 +1,183 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { TwitchWorkerMessage, TwitchWorkerResult } from '@scripts/twitch-chat-worker';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { TwitchWorkerMessage } from '@scripts/twitch-chat-worker';
 
 /**
- * Unit tests for twitch-chat-worker.ts module
- * 
- * Tests the Twitch chat message filtering worker that validates
- * messages matching /^[a-zA-Z]{4,12}$/ pattern.
+ * Unit tests for src/scripts/twitch-chat-worker.ts — the Web Worker that
+ * filters Twitch chat down to plausible WoS guesses (/^[a-zA-Z]{4,12}$/) before
+ * `GameSpectator` correlates them with masked correct-guess events.
+ *
+ * These tests drive the REAL module. An earlier version of this file declared a
+ * local copy of the worker's filtering logic inside `beforeEach` and asserted
+ * against that copy, so it imported only types, never executed a line of
+ * src/, and reported 0% coverage while appearing to pass 23 tests. Anything
+ * added here must go through `loadWorkerWithFreshScope()` so it exercises
+ * production code.
+ *
+ * The worker installs its handlers on `self` (worker scope, no DOM), so the
+ * harness stubs `globalThis.self`, imports the module so it binds to that stub,
+ * then invokes `self.onmessage` directly and asserts on `self.postMessage`.
  */
 
-// Type for mock Worker global
-interface MockWorkerGlobalScope {
+/** The subset of `WorkerGlobalScope` that twitch-chat-worker.ts actually uses. */
+interface WorkerScopeStub {
   postMessage: ReturnType<typeof vi.fn>;
   onmessage: ((event: MessageEvent) => void) | null;
-  onerror: ((event: ErrorEvent) => void) | null;
-  onmessageerror: ((event: MessageEvent) => void) | null;
-  addEventListener: ReturnType<typeof vi.fn>;
-  removeEventListener: ReturnType<typeof vi.fn>;
-  dispatchEvent: ReturnType<typeof vi.fn>;
+  onerror: ((event: unknown) => void) | null;
+  onmessageerror: ((event: unknown) => void) | null;
 }
 
-// Helper to get mock postMessage
-function getMockPostMessage(): ReturnType<typeof vi.fn> {
-  return ((global as any).self as MockWorkerGlobalScope).postMessage;
-}
+let scope: WorkerScopeStub;
 
-describe('twitch-chat-worker', () => {
-  let worker: Worker;
-  let messageHandler: (event: MessageEvent) => void;
-  let errorHandler: (event: ErrorEvent) => void;
-  let messageErrorHandler: (event: MessageEvent) => void;
+/** Fresh worker scope + a fresh module instance bound to it. */
+async function loadWorkerWithFreshScope(): Promise<void> {
+  scope = {
+    postMessage: vi.fn(),
+    onmessage: null,
+    onerror: null,
+    onmessageerror: null,
+  };
 
-  beforeEach(() => {
-    // Clear all mocks before each test
-    vi.clearAllMocks();
-
-    // Mock Worker global
-    const mockPostMessage = vi.fn();
-    const listeners: Record<string, Function> = {};
-
-    // Create mock worker environment
-    (global as any).self = {
-      postMessage: mockPostMessage,
-      onmessage: null,
-      onerror: null,
-      onmessageerror: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    } as MockWorkerGlobalScope;
-
-    // Import the worker module (this will set up the message handlers)
-    // Note: In a real environment, the worker code would be loaded in a separate context
-    // For testing, we'll simulate the worker's message handling logic
-    const messageRegex = /^[a-zA-Z]{4,12}$/;
-    
-    messageHandler = function (e: MessageEvent<TwitchWorkerMessage>) {
-      try {
-        const { username, message, timestamp } = e.data;
-
-        if (messageRegex.test(message)) {
-          const result: TwitchWorkerResult = {
-            type: 'twitch_message',
-            username: username.toLowerCase(),
-            message: message.toLowerCase(),
-            timestamp
-          };
-
-          mockPostMessage(result);
-        }
-      } catch (error: any) {
-        mockPostMessage({
-          type: 'error',
-          error: error.message
-        });
-      }
-    };
-
-    errorHandler = function (error: ErrorEvent) {
-      console.error('Twitch Worker Error:', error);
-    };
-
-    messageErrorHandler = function (error: MessageEvent) {
-      console.error('Twitch Worker Message Error:', error);
-    };
+  Object.defineProperty(globalThis, 'self', {
+    value: scope,
+    configurable: true,
+    writable: true,
   });
 
+  vi.resetModules();
+  await import('@scripts/twitch-chat-worker');
+}
+
+/** Delivers a chat message to the worker exactly as the main thread would. */
+async function send(data: Partial<TwitchWorkerMessage> | null): Promise<void> {
+  await loadWorkerWithFreshScope();
+  scope.onmessage?.(new MessageEvent('message', { data }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('twitch-chat-worker', () => {
   describe('message filtering', () => {
-    it('should accept valid 4-letter word', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'test',
-        timestamp: Date.now()
-      };
+    it.each([
+      ['a 4-letter word (lower bound)', 'word'],
+      ['a 12-letter word (upper bound)', 'exactlytwelv'],
+      ['a mixed-case word', 'WoRdS'],
+    ])('forwards %s', async (_label, message) => {
+      await send({ username: 'TestUser', message, timestamp: 1000 });
 
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith({
+      expect(scope.postMessage).toHaveBeenCalledTimes(1);
+      expect(scope.postMessage).toHaveBeenCalledWith({
         type: 'twitch_message',
         username: 'testuser',
-        message: 'test',
-        timestamp: message.timestamp
+        message: message.toLowerCase(),
+        timestamp: 1000,
       });
     });
 
-    it('should accept valid 12-letter word', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'abcdefghijkl',
-        timestamp: Date.now()
-      };
+    it.each([
+      ['3 letters (below the lower bound)', 'cat'],
+      ['13 letters (above the upper bound)', 'thirteenlettr'],
+      ['digits', 'test123'],
+      ['punctuation', 'test!'],
+      ['an embedded space', 'test word'],
+      ['an empty string', ''],
+      ['leading whitespace', ' word'],
+      ['a non-ASCII letter', 'wörd'],
+    ])('drops %s', async (_label, message) => {
+      await send({ username: 'TestUser', message, timestamp: 1000 });
 
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith({
-        type: 'twitch_message',
-        username: 'testuser',
-        message: 'abcdefghijkl',
-        timestamp: message.timestamp
-      });
-    });
-
-    it('should accept mixed case letters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'WoRdS',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith({
-        type: 'twitch_message',
-        username: 'testuser',
-        message: 'words',
-        timestamp: message.timestamp
-      });
-    });
-
-    it('should reject messages with less than 4 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'cat',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject messages with more than 12 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'abcdefghijklm',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject messages with numbers', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'test123',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject messages with special characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'test!',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject messages with spaces', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'test word',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject empty messages', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: '',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
+      expect(scope.postMessage).not.toHaveBeenCalled();
     });
   });
 
   describe('data transformation', () => {
-    it('should convert username to lowercase', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'word',
-        timestamp: Date.now()
-      };
+    it('lower-cases the username so it matches WoS event usernames', async () => {
+      await send({ username: 'TestUser', message: 'word', timestamp: 1000 });
 
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          username: 'testuser'
-        })
+      expect(scope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ username: 'testuser' }),
       );
     });
 
-    it('should convert message to lowercase', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'WORD',
-        timestamp: Date.now()
-      };
+    it('preserves the timestamp used to correlate guesses', async () => {
+      await send({ username: 'user', message: 'word', timestamp: 1234567890 });
 
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'word'
-        })
-      );
-    });
-
-    it('should preserve timestamp', () => {
-      const mockPostMessage = getMockPostMessage();
-      const timestamp = 1234567890;
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'word',
-        timestamp
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          timestamp: 1234567890
-        })
-      );
-    });
-
-    it('should include correct message type', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'TestUser',
-        message: 'word',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'twitch_message'
-        })
+      expect(scope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: 1234567890 }),
       );
     });
   });
 
-  describe('error handling', () => {
-    it('should handle malformed message data', () => {
-      const mockPostMessage = getMockPostMessage();
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      
-      // Simulate a message with missing fields (null data)
-      const malformedData = null;
+  describe('malformed input', () => {
+    it('reports an error instead of throwing when the payload is null', async () => {
+      await send(null);
 
-      messageHandler(new MessageEvent('message', { data: malformedData as unknown as TwitchWorkerMessage }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error'
-        })
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it('should handle undefined username', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: Partial<TwitchWorkerMessage> = {
-        username: undefined,
-        message: 'word',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message as TwitchWorkerMessage }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error'
-        })
+      expect(scope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
       );
     });
 
-    it('should handle undefined message', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: Partial<TwitchWorkerMessage> = {
-        username: 'TestUser',
-        message: undefined,
-        timestamp: Date.now()
-      };
+    it('reports an error when the username is missing', async () => {
+      await send({ message: 'word', timestamp: 1000 });
 
-      messageHandler(new MessageEvent('message', { data: message as TwitchWorkerMessage }));
-
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error'
-        })
+      expect(scope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
       );
     });
 
-    it('should log errors via onerror handler', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const errorEvent = new ErrorEvent('error', {
-        message: 'Test error',
-        error: new Error('Test error')
-      });
+    it('reports an error when the message is missing', async () => {
+      // Note: `messageRegex.test(undefined)` coerces to the string "undefined",
+      // which is 9 ASCII letters and so passes the filter. The failure surfaces
+      // one line later on `message.toLowerCase()` and is caught. Asserting the
+      // error path here pins that behaviour.
+      await send({ username: 'user', timestamp: 1000 });
 
-      errorHandler(errorEvent);
-
-      expect(consoleSpy).toHaveBeenCalledWith('Twitch Worker Error:', errorEvent);
-      consoleSpy.mockRestore();
+      expect(scope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
+      );
     });
 
-    it('should log message errors via onmessageerror handler', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const messageEvent = new MessageEvent('messageerror', {
-        data: 'corrupted data'
-      });
-
-      messageErrorHandler(messageEvent);
-
-      expect(consoleSpy).toHaveBeenCalledWith('Twitch Worker Message Error:', messageEvent);
-      consoleSpy.mockRestore();
+    it('never lets an error escape the worker', async () => {
+      await expect(send(null)).resolves.toBeUndefined();
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle exactly 4 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'user',
-        message: 'word',
-        timestamp: Date.now()
-      };
+  describe('sequences', () => {
+    it('forwards only the valid messages in a mixed batch', async () => {
+      await loadWorkerWithFreshScope();
 
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle exactly 12 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'user',
-        message: 'exactlytwelv',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).toHaveBeenCalledTimes(1);
-    });
-
-    it('should reject 3 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'user',
-        message: 'cat',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should reject 13 characters', () => {
-      const mockPostMessage = getMockPostMessage();
-      const message: TwitchWorkerMessage = {
-        username: 'user',
-        message: 'thirteenlettr',
-        timestamp: Date.now()
-      };
-
-      messageHandler(new MessageEvent('message', { data: message }));
-
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it('should handle multiple valid messages in sequence', () => {
-      const mockPostMessage = getMockPostMessage();
-      const messages: TwitchWorkerMessage[] = [
+      const batch: TwitchWorkerMessage[] = [
         { username: 'user1', message: 'word', timestamp: 1000 },
-        { username: 'user2', message: 'test', timestamp: 2000 },
-        { username: 'user3', message: 'game', timestamp: 3000 }
+        { username: 'user2', message: 'hi', timestamp: 2000 },
+        { username: 'user3', message: 'test123', timestamp: 3000 },
+        { username: 'user4', message: 'game', timestamp: 4000 },
       ];
+      for (const data of batch) {
+        scope.onmessage?.(new MessageEvent('message', { data }));
+      }
 
-      messages.forEach(msg => {
-        messageHandler(new MessageEvent('message', { data: msg }));
-      });
-
-      expect(mockPostMessage).toHaveBeenCalledTimes(3);
+      expect(scope.postMessage).toHaveBeenCalledTimes(2);
+      expect(scope.postMessage).toHaveBeenNthCalledWith(1,
+        expect.objectContaining({ message: 'word' }));
+      expect(scope.postMessage).toHaveBeenNthCalledWith(2,
+        expect.objectContaining({ message: 'game' }));
     });
+  });
 
-    it('should filter out invalid messages from sequence', () => {
-      const mockPostMessage = getMockPostMessage();
-      const messages: TwitchWorkerMessage[] = [
-        { username: 'user1', message: 'word', timestamp: 1000 },      // valid
-        { username: 'user2', message: 'hi', timestamp: 2000 },        // invalid (too short)
-        { username: 'user3', message: 'test123', timestamp: 3000 },   // invalid (numbers)
-        { username: 'user4', message: 'game', timestamp: 4000 }       // valid
-      ];
+  describe('worker-level handlers', () => {
+    it('installs onerror and onmessageerror handlers that log', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+      await loadWorkerWithFreshScope();
 
-      messages.forEach(msg => {
-        messageHandler(new MessageEvent('message', { data: msg }));
-      });
+      expect(scope.onerror).toBeTypeOf('function');
+      expect(scope.onmessageerror).toBeTypeOf('function');
 
-      expect(mockPostMessage).toHaveBeenCalledTimes(2);
+      scope.onerror?.('boom');
+      scope.onmessageerror?.('corrupt');
+
+      expect(consoleSpy).toHaveBeenCalledWith('Twitch Worker Error:', 'boom');
+      expect(consoleSpy).toHaveBeenCalledWith('Twitch Worker Message Error:', 'corrupt');
     });
   });
 });

--- a/tests/unit/wos-worker.test.ts
+++ b/tests/unit/wos-worker.test.ts
@@ -110,7 +110,7 @@ const eventTable: EventRow[] = [
   {
     eventType: 1,
     fixture: '01-level-start.json',
-    message: levelStart as WosWorkerMessage,
+    message: levelStart,
     expectedName: 'Level Started',
     expected: {
       level: 3,
@@ -124,13 +124,13 @@ const eventTable: EventRow[] = [
   {
     eventType: 2,
     fixture: '02-unknown-unhandled.json',
-    message: unknown02 as WosWorkerMessage,
+    message: unknown02,
     expectedName: null, // no branch in wos-worker.ts; meaning unknown
   },
   {
     eventType: 3,
     fixture: '03-correct-guess.json',
-    message: correctGuess as WosWorkerMessage,
+    message: correctGuess,
     expectedName: 'Correct Guess',
     expected: {
       username: 'smc_may_i', // lowercased by the worker
@@ -142,7 +142,7 @@ const eventTable: EventRow[] = [
   {
     eventType: 3,
     fixture: '03-correct-guess-hidden.json',
-    message: correctGuessHidden as WosWorkerMessage,
+    message: correctGuessHidden,
     expectedName: 'Correct Guess',
     expected: {
       username: 'clarkio',
@@ -156,61 +156,61 @@ const eventTable: EventRow[] = [
   {
     eventType: 4,
     fixture: '04-level-results.json',
-    message: levelResults as WosWorkerMessage,
+    message: levelResults,
     expectedName: 'Level Results',
     expected: { stars: 5 },
   },
   {
     eventType: 5,
     fixture: '05-game-ended.json',
-    message: gameEnded as WosWorkerMessage,
+    message: gameEnded,
     expectedName: 'Game Ended',
     expected: { level: 12 },
   },
   {
     eventType: 6,
     fixture: '06-unknown-unhandled.json',
-    message: unknown06 as WosWorkerMessage,
+    message: unknown06,
     expectedName: null, // no branch in wos-worker.ts; meaning unknown
   },
   {
     eventType: 7,
     fixture: '07-letters-cycled.json',
-    message: lettersCycled as WosWorkerMessage,
+    message: lettersCycled,
     expectedName: 'Letters Cycled',
     expected: { letters: ['n', 'o', 'i', 't', 'u', 'a', 'c'] },
   },
   {
     eventType: 8,
     fixture: '08-level-ended.json',
-    message: levelEnded as WosWorkerMessage,
+    message: levelEnded,
     expectedName: 'Level Ended',
     expected: { level: 3 },
   },
   {
     eventType: 9,
     fixture: '09-unknown-unhandled.json',
-    message: unknown09 as WosWorkerMessage,
+    message: unknown09,
     expectedName: null, // no branch in wos-worker.ts; meaning unknown
   },
   {
     eventType: 10,
     fixture: '10-letters-revealed.json',
-    message: lettersRevealed as WosWorkerMessage,
+    message: lettersRevealed,
     expectedName: 'Hidden/Fake Letters Revealed',
     expected: { hiddenLetters: ['a'], falseLetters: ['x', 'z'] },
   },
   {
     eventType: 11,
     fixture: '11-guessing-unlocked.json',
-    message: guessingUnlocked as WosWorkerMessage,
+    message: guessingUnlocked,
     expectedName: 'Guessing Unlocked',
     expected: { letters: [], slots: [], level: 0 },
   },
   {
     eventType: 12,
     fixture: '12-game-connected.json',
-    message: gameConnected as WosWorkerMessage,
+    message: gameConnected,
     expectedName: 'Game Connected',
     expected: {
       level: 7,
@@ -252,7 +252,7 @@ describe('wos-worker', () => {
     it.each(unhandled)(
       'event $eventType ($fixture) is ignored without throwing',
       ({ message, eventType }) => {
-        expect(() => send(message)).not.toThrow();
+        expect(() => { send(message); }).not.toThrow();
 
         expect(scope.postMessage).not.toHaveBeenCalled();
         expect(consoleLogSpy).toHaveBeenCalledWith(
@@ -274,7 +274,7 @@ describe('wos-worker', () => {
 
   describe('posted payload shape', () => {
     it('posts the complete result for a level start', () => {
-      send(levelStart as WosWorkerMessage);
+      send(levelStart);
 
       expect(postedResult()).toEqual({
         type: 'wos_event',
@@ -295,7 +295,7 @@ describe('wos-worker', () => {
     });
 
     it('posts the complete result for a correct guess', () => {
-      send(correctGuess as WosWorkerMessage);
+      send(correctGuess);
 
       expect(postedResult()).toEqual({
         type: 'wos_event',
@@ -320,7 +320,7 @@ describe('wos-worker', () => {
     });
 
     it('posts the complete result for game connected, including record and language', () => {
-      send(gameConnected as WosWorkerMessage);
+      send(gameConnected);
 
       expect(postedResult()).toEqual({
         type: 'wos_event',
@@ -341,9 +341,12 @@ describe('wos-worker', () => {
     });
 
     it('drops the event 4 ranking data (it is not forwarded to the main thread)', () => {
-      send(levelResults as WosWorkerMessage);
+      send(levelResults);
 
-      const result = postedResult() as Record<string, unknown>;
+      // Via `unknown`: WosWorkerResult is a closed shape, so TS rejects the
+      // direct widening. The point of this test is to inspect keys the type
+      // says should not be there at all.
+      const result = postedResult() as unknown as Record<string, unknown>;
       expect(result.stars).toBe(5);
       expect(result).not.toHaveProperty('ranking');
       expect(result).not.toHaveProperty('rankingTurn');
@@ -352,7 +355,7 @@ describe('wos-worker', () => {
     it('only forwards `record` for event 12', () => {
       // Event 5 carries no record, and the worker leaves the field undefined
       // for every event other than Game Connected.
-      send(gameEnded as WosWorkerMessage);
+      send(gameEnded);
       expect(postedResult().record).toBeUndefined();
     });
 
@@ -371,18 +374,18 @@ describe('wos-worker', () => {
       // Documents current behavior: `currentLevel` is tracked inside the worker
       // but never written back into the posted result, so an event without a
       // level reports 0 even right after a level-start event.
-      send(levelStart as WosWorkerMessage);
+      send(levelStart);
       expect(postedResult().level).toBe(3);
 
       scope.postMessage.mockClear();
-      send(correctGuess as WosWorkerMessage);
+      send(correctGuess);
       expect(postedResult().level).toBe(0);
     });
 
     it('posts exactly one message per handled event', () => {
-      send(levelStart as WosWorkerMessage);
-      send(correctGuess as WosWorkerMessage);
-      send(lettersRevealed as WosWorkerMessage);
+      send(levelStart);
+      send(correctGuess);
+      send(lettersRevealed);
 
       expect(scope.postMessage).toHaveBeenCalledTimes(3);
     });
@@ -395,13 +398,13 @@ describe('wos-worker', () => {
     // subsequent game event.
 
     it('does not throw and reports an error when the message is null', () => {
-      expect(() => send(null)).not.toThrow();
+      expect(() => { send(null); }).not.toThrow();
 
       expect(postedResult()).toMatchObject({ type: 'error' });
     });
 
     it('does not throw and reports an error when `data` is missing', () => {
-      expect(() => send({ eventType: 3 })).not.toThrow();
+      expect(() => { send({ eventType: 3 }); }).not.toThrow();
 
       const result = postedResult() as unknown as { type: string; error: string };
       expect(result.type).toBe('error');
@@ -409,13 +412,13 @@ describe('wos-worker', () => {
     });
 
     it('does not throw and reports an error when `data` is null', () => {
-      expect(() => send({ eventType: 1, data: null })).not.toThrow();
+      expect(() => { send({ eventType: 1, data: null }); }).not.toThrow();
 
       expect(postedResult()).toMatchObject({ type: 'error' });
     });
 
     it('fills defaults for an empty payload', () => {
-      expect(() => send({ eventType: 1, data: {} })).not.toThrow();
+      expect(() => { send({ eventType: 1, data: {} }); }).not.toThrow();
 
       expect(postedResult()).toEqual({
         type: 'wos_event',
@@ -436,11 +439,11 @@ describe('wos-worker', () => {
     });
 
     it('fills defaults when nested user data is partial', () => {
-      expect(() => send({ eventType: 3, data: { user: {} } })).not.toThrow();
+      expect(() => { send({ eventType: 3, data: { user: {} } }); }).not.toThrow();
       expect(postedResult().username).toBe('');
 
       scope.postMessage.mockClear();
-      expect(() => send({ eventType: 3, data: { user: null } })).not.toThrow();
+      expect(() => { send({ eventType: 3, data: { user: null } }); }).not.toThrow();
       expect(postedResult().username).toBe('');
     });
 
@@ -450,7 +453,7 @@ describe('wos-worker', () => {
       // coerced or rejected. Asserted here so a future change to that contract
       // is a deliberate one.
       expect(() =>
-        send({
+        { send({
           eventType: 3,
           data: {
             user: { name: 'someone' },
@@ -459,7 +462,7 @@ describe('wos-worker', () => {
             hitMax: 'yes',
             stars: '5',
           },
-        })
+        }); }
       ).not.toThrow();
 
       expect(postedResult()).toMatchObject({
@@ -472,7 +475,7 @@ describe('wos-worker', () => {
     });
 
     it('does not throw when `data` is a primitive', () => {
-      expect(() => send({ eventType: 1, data: 42 })).not.toThrow();
+      expect(() => { send({ eventType: 1, data: 42 }); }).not.toThrow();
 
       expect(postedResult()).toMatchObject({
         type: 'wos_event',
@@ -486,7 +489,7 @@ describe('wos-worker', () => {
       // Socket.IO delivers the event type as a number today. Strict `===`
       // comparisons mean a stringified type would fall through to the
       // unhandled branch rather than being processed.
-      expect(() => send({ eventType: '3', data: { letters: ['c'] } })).not.toThrow();
+      expect(() => { send({ eventType: '3', data: { letters: ['c'] } }); }).not.toThrow();
 
       expect(scope.postMessage).not.toHaveBeenCalled();
       expect(consoleLogSpy).toHaveBeenCalledWith(
@@ -505,7 +508,7 @@ describe('wos-worker', () => {
       ['string message', 'not-a-message'],
       ['number message', 7],
     ])('survives %s', (_label, message) => {
-      expect(() => send(message)).not.toThrow();
+      expect(() => { send(message); }).not.toThrow();
 
       // Either it was ignored, or it reported an error — never a thrown
       // exception, and never a bogus wos_event.
@@ -517,7 +520,7 @@ describe('wos-worker', () => {
       send(null);
       scope.postMessage.mockClear();
 
-      send(correctGuess as WosWorkerMessage);
+      send(correctGuess);
 
       expect(postedResult()).toMatchObject({
         type: 'wos_event',
@@ -538,7 +541,7 @@ describe('wos-worker', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
       const error = new Error('boom');
 
-      expect(() => scope.onerror!(error)).not.toThrow();
+      expect(() => { scope.onerror!(error); }).not.toThrow();
       expect(consoleErrorSpy).toHaveBeenCalledWith('WOS Worker error:', error);
 
       consoleErrorSpy.mockRestore();
@@ -548,7 +551,7 @@ describe('wos-worker', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
       const event = { data: 'corrupted' };
 
-      expect(() => scope.onmessageerror!(event)).not.toThrow();
+      expect(() => { scope.onmessageerror!(event); }).not.toThrow();
       expect(consoleErrorSpy).toHaveBeenCalledWith('WOS Worker Message Error:', event);
 
       consoleErrorSpy.mockRestore();

--- a/tests/unit/wos-worker.test.ts
+++ b/tests/unit/wos-worker.test.ts
@@ -146,9 +146,11 @@ const eventTable: EventRow[] = [
     expectedName: 'Correct Guess',
     expected: {
       username: 'clarkio',
-      // '?' placeholders survive untouched; the main thread resolves them
-      // against the Twitch chat log.
-      letters: ['c', '?', 'u', 't', 'i', 'o', 'n'],
+      // A hidden guess masks EVERY letter of the word, not a subset — the
+      // length is all the main thread learns from the event itself. The
+      // placeholders survive the worker untouched; the main thread resolves
+      // the word against the Twitch chat log.
+      letters: ['?', '?', '?', '?', '?', '?', '?'],
       index: 3,
       hitMax: true,
     },

--- a/tests/unit/wos-worker.test.ts
+++ b/tests/unit/wos-worker.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { WosWorkerMessage, WosWorkerResult } from '@scripts/wos-worker';
+
+import levelStart from '../fixtures/wos-events/01-level-start.json';
+import unknown02 from '../fixtures/wos-events/02-unknown-unhandled.json';
+import correctGuess from '../fixtures/wos-events/03-correct-guess.json';
+import correctGuessHidden from '../fixtures/wos-events/03-correct-guess-hidden.json';
+import levelResults from '../fixtures/wos-events/04-level-results.json';
+import gameEnded from '../fixtures/wos-events/05-game-ended.json';
+import unknown06 from '../fixtures/wos-events/06-unknown-unhandled.json';
+import lettersCycled from '../fixtures/wos-events/07-letters-cycled.json';
+import levelEnded from '../fixtures/wos-events/08-level-ended.json';
+import unknown09 from '../fixtures/wos-events/09-unknown-unhandled.json';
+import lettersRevealed from '../fixtures/wos-events/10-letters-revealed.json';
+import guessingUnlocked from '../fixtures/wos-events/11-guessing-unlocked.json';
+import gameConnected from '../fixtures/wos-events/12-game-connected.json';
+
+/**
+ * Unit tests for src/scripts/wos-worker.ts — the Web Worker that turns raw WoS
+ * socket events into the `wos_event` messages `GameSpectator` consumes.
+ *
+ * The worker runs in worker scope: it installs its handlers on `self`, not on
+ * `window`, and it never touches the DOM. So instead of spawning a real
+ * `Worker` (which vitest's setup file stubs out anyway) these tests install a
+ * minimal worker-scope stub on `globalThis.self`, import the module so it binds
+ * its handlers to that stub, and then drive `self.onmessage` directly and
+ * assert on `self.postMessage`.
+ *
+ * Fixtures live in tests/fixtures/wos-events/ — see the README there for which
+ * payload fields are known protocol and which are inferred.
+ */
+
+/** The subset of `WorkerGlobalScope` that wos-worker.ts actually uses. */
+interface WorkerScopeStub {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  onmessageerror: ((event: unknown) => void) | null;
+}
+
+let scope: WorkerScopeStub;
+let originalSelf: PropertyDescriptor | undefined;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+/** Fresh worker scope + a fresh module instance (the worker holds module state). */
+async function loadWorkerWithFreshScope(): Promise<void> {
+  scope = {
+    postMessage: vi.fn(),
+    onmessage: null,
+    onerror: null,
+    onmessageerror: null,
+  };
+
+  Object.defineProperty(globalThis, 'self', {
+    value: scope,
+    configurable: true,
+    writable: true,
+  });
+
+  vi.resetModules();
+  await import('@scripts/wos-worker');
+}
+
+/** Deliver a message to the worker exactly as the runtime would. */
+function send(message: unknown): void {
+  scope.onmessage!({ data: message } as MessageEvent);
+}
+
+/** The single result the worker posted (fails if it posted zero or many). */
+function postedResult(): WosWorkerResult {
+  expect(scope.postMessage).toHaveBeenCalledTimes(1);
+  return scope.postMessage.mock.calls[0][0] as WosWorkerResult;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  originalSelf = Object.getOwnPropertyDescriptor(globalThis, 'self');
+  // The worker console.logs unhandled event types; keep the run quiet but
+  // assertable.
+  consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+  await loadWorkerWithFreshScope();
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+  if (originalSelf) {
+    Object.defineProperty(globalThis, 'self', originalSelf);
+  } else {
+    delete (globalThis as Record<string, unknown>).self;
+  }
+});
+
+/**
+ * One row per WoS event type number, 1 through 12.
+ *
+ * `expectedName` is the `wosEventName` the worker labels the event with, or
+ * `null` for the numbers the worker has no branch for — those must produce no
+ * postMessage at all. `expected` is asserted as a subset of the posted payload;
+ * three representative rows are additionally asserted whole further down.
+ */
+interface EventRow {
+  eventType: number;
+  fixture: string;
+  message: WosWorkerMessage;
+  expectedName: string | null;
+  expected?: Partial<WosWorkerResult>;
+}
+
+const eventTable: EventRow[] = [
+  {
+    eventType: 1,
+    fixture: '01-level-start.json',
+    message: levelStart as WosWorkerMessage,
+    expectedName: 'Level Started',
+    expected: {
+      level: 3,
+      letters: ['c', 'a', 'u', 't', 'i', 'o', 'n'],
+      slots: levelStart.data.slots,
+      username: '',
+      stars: 0,
+      hitMax: false,
+    },
+  },
+  {
+    eventType: 2,
+    fixture: '02-unknown-unhandled.json',
+    message: unknown02 as WosWorkerMessage,
+    expectedName: null, // no branch in wos-worker.ts; meaning unknown
+  },
+  {
+    eventType: 3,
+    fixture: '03-correct-guess.json',
+    message: correctGuess as WosWorkerMessage,
+    expectedName: 'Correct Guess',
+    expected: {
+      username: 'smc_may_i', // lowercased by the worker
+      letters: ['c', 'o', 'a', 't'],
+      index: 2,
+      hitMax: false,
+    },
+  },
+  {
+    eventType: 3,
+    fixture: '03-correct-guess-hidden.json',
+    message: correctGuessHidden as WosWorkerMessage,
+    expectedName: 'Correct Guess',
+    expected: {
+      username: 'clarkio',
+      // '?' placeholders survive untouched; the main thread resolves them
+      // against the Twitch chat log.
+      letters: ['c', '?', 'u', 't', 'i', 'o', 'n'],
+      index: 3,
+      hitMax: true,
+    },
+  },
+  {
+    eventType: 4,
+    fixture: '04-level-results.json',
+    message: levelResults as WosWorkerMessage,
+    expectedName: 'Level Results',
+    expected: { stars: 5 },
+  },
+  {
+    eventType: 5,
+    fixture: '05-game-ended.json',
+    message: gameEnded as WosWorkerMessage,
+    expectedName: 'Game Ended',
+    expected: { level: 12 },
+  },
+  {
+    eventType: 6,
+    fixture: '06-unknown-unhandled.json',
+    message: unknown06 as WosWorkerMessage,
+    expectedName: null, // no branch in wos-worker.ts; meaning unknown
+  },
+  {
+    eventType: 7,
+    fixture: '07-letters-cycled.json',
+    message: lettersCycled as WosWorkerMessage,
+    expectedName: 'Letters Cycled',
+    expected: { letters: ['n', 'o', 'i', 't', 'u', 'a', 'c'] },
+  },
+  {
+    eventType: 8,
+    fixture: '08-level-ended.json',
+    message: levelEnded as WosWorkerMessage,
+    expectedName: 'Level Ended',
+    expected: { level: 3 },
+  },
+  {
+    eventType: 9,
+    fixture: '09-unknown-unhandled.json',
+    message: unknown09 as WosWorkerMessage,
+    expectedName: null, // no branch in wos-worker.ts; meaning unknown
+  },
+  {
+    eventType: 10,
+    fixture: '10-letters-revealed.json',
+    message: lettersRevealed as WosWorkerMessage,
+    expectedName: 'Hidden/Fake Letters Revealed',
+    expected: { hiddenLetters: ['a'], falseLetters: ['x', 'z'] },
+  },
+  {
+    eventType: 11,
+    fixture: '11-guessing-unlocked.json',
+    message: guessingUnlocked as WosWorkerMessage,
+    expectedName: 'Guessing Unlocked',
+    expected: { letters: [], slots: [], level: 0 },
+  },
+  {
+    eventType: 12,
+    fixture: '12-game-connected.json',
+    message: gameConnected as WosWorkerMessage,
+    expectedName: 'Game Connected',
+    expected: {
+      level: 7,
+      record: 21, // only event 12 carries the channel record through
+      language: 2,
+      letters: ['r', 'e', 'a', 'l', 'i', 't', 'y'],
+      slots: gameConnected.data.slots,
+    },
+  },
+];
+
+describe('wos-worker', () => {
+  describe('event type table (all 12 WoS event numbers)', () => {
+    const handled = eventTable.filter(row => row.expectedName !== null);
+    const unhandled = eventTable.filter(row => row.expectedName === null);
+
+    it('covers every event type number from 1 to 12', () => {
+      const covered = new Set(eventTable.map(row => row.eventType));
+      expect([...covered].sort((a, b) => a - b)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+      ]);
+    });
+
+    it.each(handled)(
+      'event $eventType ($fixture) -> "$expectedName"',
+      async ({ message, eventType, expectedName, expected }) => {
+        send(message);
+
+        const result = postedResult();
+        expect(result).toMatchObject({
+          type: 'wos_event',
+          wosEventType: eventType,
+          wosEventName: expectedName,
+          ...expected,
+        });
+      }
+    );
+
+    it.each(unhandled)(
+      'event $eventType ($fixture) is ignored without throwing',
+      ({ message, eventType }) => {
+        expect(() => send(message)).not.toThrow();
+
+        expect(scope.postMessage).not.toHaveBeenCalled();
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          `[WOS Worker] Unhandled WOS event type: ${eventType}`
+        );
+      }
+    );
+
+    it('has a table row for every fixture file on disk', async () => {
+      const fixtureModules = import.meta.glob('../fixtures/wos-events/*.json');
+      const onDisk = Object.keys(fixtureModules)
+        .map(path => path.split('/').pop()!)
+        .sort();
+      const inTable = eventTable.map(row => row.fixture).sort();
+
+      expect(inTable).toEqual(onDisk);
+    });
+  });
+
+  describe('posted payload shape', () => {
+    it('posts the complete result for a level start', () => {
+      send(levelStart as WosWorkerMessage);
+
+      expect(postedResult()).toEqual({
+        type: 'wos_event',
+        wosEventType: 1,
+        wosEventName: 'Level Started',
+        username: '',
+        index: 0,
+        letters: ['c', 'a', 'u', 't', 'i', 'o', 'n'],
+        stars: 0,
+        level: 3,
+        record: undefined,
+        hitMax: false,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: levelStart.data.slots,
+        language: undefined,
+      });
+    });
+
+    it('posts the complete result for a correct guess', () => {
+      send(correctGuess as WosWorkerMessage);
+
+      expect(postedResult()).toEqual({
+        type: 'wos_event',
+        wosEventType: 3,
+        wosEventName: 'Correct Guess',
+        username: 'smc_may_i',
+        index: 2,
+        letters: ['c', 'o', 'a', 't'],
+        stars: 0,
+        // The correct-guess payload carries no level, and the worker's
+        // module-level `currentLevel` is never read back into the result, so
+        // level is reported as 0 here. GameSpectator only reads `level` for
+        // events 1 and 12, which do carry it.
+        level: 0,
+        record: undefined,
+        hitMax: false,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: [],
+        language: undefined,
+      });
+    });
+
+    it('posts the complete result for game connected, including record and language', () => {
+      send(gameConnected as WosWorkerMessage);
+
+      expect(postedResult()).toEqual({
+        type: 'wos_event',
+        wosEventType: 12,
+        wosEventName: 'Game Connected',
+        username: '',
+        index: 0,
+        letters: ['r', 'e', 'a', 'l', 'i', 't', 'y'],
+        stars: 0,
+        level: 7,
+        record: 21,
+        hitMax: false,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: gameConnected.data.slots,
+        language: 2,
+      });
+    });
+
+    it('drops the event 4 ranking data (it is not forwarded to the main thread)', () => {
+      send(levelResults as WosWorkerMessage);
+
+      const result = postedResult() as Record<string, unknown>;
+      expect(result.stars).toBe(5);
+      expect(result).not.toHaveProperty('ranking');
+      expect(result).not.toHaveProperty('rankingTurn');
+    });
+
+    it('only forwards `record` for event 12', () => {
+      // Event 5 carries no record, and the worker leaves the field undefined
+      // for every event other than Game Connected.
+      send(gameEnded as WosWorkerMessage);
+      expect(postedResult().record).toBeUndefined();
+    });
+
+    it('lowercases the username but leaves letters untouched', () => {
+      send({
+        eventType: 3,
+        data: { user: { name: 'MiXeDcAsE' }, letters: ['A', 'b', 'C', 'd'], index: 0 },
+      });
+
+      const result = postedResult();
+      expect(result.username).toBe('mixedcase');
+      expect(result.letters).toEqual(['A', 'b', 'C', 'd']);
+    });
+
+    it('does not carry level forward between events', () => {
+      // Documents current behavior: `currentLevel` is tracked inside the worker
+      // but never written back into the posted result, so an event without a
+      // level reports 0 even right after a level-start event.
+      send(levelStart as WosWorkerMessage);
+      expect(postedResult().level).toBe(3);
+
+      scope.postMessage.mockClear();
+      send(correctGuess as WosWorkerMessage);
+      expect(postedResult().level).toBe(0);
+    });
+
+    it('posts exactly one message per handled event', () => {
+      send(levelStart as WosWorkerMessage);
+      send(correctGuess as WosWorkerMessage);
+      send(lettersRevealed as WosWorkerMessage);
+
+      expect(scope.postMessage).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('malformed input', () => {
+    // The worker thread must survive anything the socket hands it: a thrown
+    // error inside onmessage would surface as an unhandled worker error and
+    // (depending on the browser) tear down the worker, silently killing every
+    // subsequent game event.
+
+    it('does not throw and reports an error when the message is null', () => {
+      expect(() => send(null)).not.toThrow();
+
+      expect(postedResult()).toMatchObject({ type: 'error' });
+    });
+
+    it('does not throw and reports an error when `data` is missing', () => {
+      expect(() => send({ eventType: 3 })).not.toThrow();
+
+      const result = postedResult() as unknown as { type: string; error: string };
+      expect(result.type).toBe('error');
+      expect(typeof result.error).toBe('string');
+    });
+
+    it('does not throw and reports an error when `data` is null', () => {
+      expect(() => send({ eventType: 1, data: null })).not.toThrow();
+
+      expect(postedResult()).toMatchObject({ type: 'error' });
+    });
+
+    it('fills defaults for an empty payload', () => {
+      expect(() => send({ eventType: 1, data: {} })).not.toThrow();
+
+      expect(postedResult()).toEqual({
+        type: 'wos_event',
+        wosEventType: 1,
+        wosEventName: 'Level Started',
+        username: '',
+        index: 0,
+        letters: [],
+        stars: 0,
+        level: 0,
+        record: undefined,
+        hitMax: false,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: [],
+        language: undefined,
+      });
+    });
+
+    it('fills defaults when nested user data is partial', () => {
+      expect(() => send({ eventType: 3, data: { user: {} } })).not.toThrow();
+      expect(postedResult().username).toBe('');
+
+      scope.postMessage.mockClear();
+      expect(() => send({ eventType: 3, data: { user: null } })).not.toThrow();
+      expect(postedResult().username).toBe('');
+    });
+
+    it('does not throw when fields have the wrong types', () => {
+      // The worker is a pass-through: it does no type validation, so a
+      // wrongly-typed field reaches the main thread as-is rather than being
+      // coerced or rejected. Asserted here so a future change to that contract
+      // is a deliberate one.
+      expect(() =>
+        send({
+          eventType: 3,
+          data: {
+            user: { name: 'someone' },
+            letters: 'coat',
+            index: 'two',
+            hitMax: 'yes',
+            stars: '5',
+          },
+        })
+      ).not.toThrow();
+
+      expect(postedResult()).toMatchObject({
+        wosEventType: 3,
+        letters: 'coat',
+        index: 'two',
+        hitMax: 'yes',
+        stars: '5',
+      });
+    });
+
+    it('does not throw when `data` is a primitive', () => {
+      expect(() => send({ eventType: 1, data: 42 })).not.toThrow();
+
+      expect(postedResult()).toMatchObject({
+        type: 'wos_event',
+        wosEventType: 1,
+        letters: [],
+        level: 0,
+      });
+    });
+
+    it('ignores an event type sent as a string (matching is strict)', () => {
+      // Socket.IO delivers the event type as a number today. Strict `===`
+      // comparisons mean a stringified type would fall through to the
+      // unhandled branch rather than being processed.
+      expect(() => send({ eventType: '3', data: { letters: ['c'] } })).not.toThrow();
+
+      expect(scope.postMessage).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[WOS Worker] Unhandled WOS event type: 3'
+      );
+    });
+
+    it.each([
+      ['missing event type', { data: { level: 1 } }],
+      ['null event type', { eventType: null, data: {} }],
+      ['negative event type', { eventType: -1, data: {} }],
+      ['float event type', { eventType: 3.5, data: {} }],
+      ['out-of-range event type', { eventType: 999, data: {} }],
+      ['empty object', {}],
+      ['array message', []],
+      ['string message', 'not-a-message'],
+      ['number message', 7],
+    ])('survives %s', (_label, message) => {
+      expect(() => send(message)).not.toThrow();
+
+      // Either it was ignored, or it reported an error — never a thrown
+      // exception, and never a bogus wos_event.
+      const posted = scope.postMessage.mock.calls.map(call => call[0]?.type);
+      expect(posted.every((type: string) => type === 'error')).toBe(true);
+    });
+
+    it('keeps processing valid events after a malformed one', () => {
+      send(null);
+      scope.postMessage.mockClear();
+
+      send(correctGuess as WosWorkerMessage);
+
+      expect(postedResult()).toMatchObject({
+        type: 'wos_event',
+        wosEventType: 3,
+        username: 'smc_may_i',
+      });
+    });
+  });
+
+  describe('worker scope handlers', () => {
+    it('installs onmessage, onerror and onmessageerror handlers', () => {
+      expect(typeof scope.onmessage).toBe('function');
+      expect(typeof scope.onerror).toBe('function');
+      expect(typeof scope.onmessageerror).toBe('function');
+    });
+
+    it('logs worker errors instead of rethrowing them', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+      const error = new Error('boom');
+
+      expect(() => scope.onerror!(error)).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('WOS Worker error:', error);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('logs message deserialization errors instead of rethrowing them', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+      const event = { data: 'corrupted' };
+
+      expect(() => scope.onmessageerror!(event)).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('WOS Worker Message Error:', event);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Second PR in the `AGENTIC-TESTING-PLAN.md` sequence (tracker: #157). Completes the **unit test stream**: #149 and #150.

**Stacked on #145** — based on that branch so it can be reviewed independently. GitHub will retarget this to `main` automatically once #145 merges.

## What changed

**#149 — Web Worker unit tests**

| File | Before | After |
|---|---|---|
| `wos-worker.ts` | 0% (nothing imported it) | **100% statements / 97.5% branches** |
| `twitch-chat-worker.ts` | 0% | **100% statements** |

`wos-worker.ts` is now covered table-driven across all 12 WoS event types, using fixtures in `tests/fixtures/wos-events/`. Fields that had to be inferred from consuming code rather than known protocol are flagged as inferred in that directory's README.

**`twitch-chat-worker.test.ts` needed a rewrite, and the reason is worth flagging.** The existing file declared a copy of the worker's filtering logic inside `beforeEach` and asserted against *that copy*. It imported only types, never executed a line of `src/`, and reported 0% coverage — while presenting 23 passing tests. It is exactly the failure mode this plan exists to catch: a suite that looks thorough and proves nothing. Rewritten to drive the real module through a worker-scope stub, with a comment at the top so it doesn't regress.

**#150 — Property-based tests** (fast-check 4, explicit seed, bounded runs)

- **`wos-words`**: buildability, dictionary membership, permutation invariance, monotonicity, `minLength`, known-word exclusion, and the `*`-marker invariant that now permanently guards the bug fixed in #148. The letter-frequency check is **reimplemented independently in the test** rather than importing the production helper — otherwise the property would be tautological.
- **`board-utils`**: idempotence (`f(f(x)) === f(x)`), output-alphabet, totality, and the 50-character boundary (random strings almost never land on a boundary, so it gets its own generator).
- **`mirror-url`**: UUID round-trip and validator agreement.

## Fixes needed along the way

- **`fc.char()` doesn't exist in fast-check 4** — it was removed. The property suite couldn't even load. Replaced with a length-1 string generator, verified against the installed package's actual exports rather than assumed.
- Two narrow `no-misused-spread` suppressions, each justified inline (generated strings are ASCII-only by construction).
- One via-`unknown` cast where a test deliberately inspects keys the closed result type says shouldn't exist.

## Verification

```
pnpm run check    →  0 errors
pnpm run lint     →  clean at --max-warnings 0
pnpm run test:run →  376 passed | 16 todo
pnpm run build    →  OK
```

Coverage **68.45% → 73.22%** statements. The 16 remaining todos are all API routes, superseded by #151.

## Notes

- Dependency added: `fast-check` 4.9.0, exact-pinned per repo convention.
- No production code changed in this PR.

https://claude.ai/code/session_01PWtckmFpZAYz8VsfzQAfHH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWtckmFpZAYz8VsfzQAfHH)_