### PR TITLE
Enforce coverage thresholds with a ratchet-only policy (#155)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -20,7 +20,7 @@ describe intent, not status. This section is the status.
 | 1 — Static analysis gate (ESLint 9 flat, type-aware) | [#147](https://github.com/clarkio/wos-plus/issues/147) | ✅ done | PR #159 |
 | 2a — Close the unit-test gap in `wos-words.ts` | [#148](https://github.com/clarkio/wos-plus/issues/148) | ✅ done | PR #159 |
 | 2b — Fixture-driven tests for `wos-worker` | [#149](https://github.com/clarkio/wos-plus/issues/149) | ✅ done | PR #159 |
-| **2c — Coverage thresholds + ratchet** | [**#155**](https://github.com/clarkio/wos-plus/issues/155) | ⬜ **not started** | — |
+| 2c — Coverage thresholds + ratchet | [#155](https://github.com/clarkio/wos-plus/issues/155) | ✅ done | this PR |
 | 3 — Acceptance-test stream (ATDD) | [#151](https://github.com/clarkio/wos-plus/issues/151) | ✅ done | PR #160 |
 | 4 — Property-based tests (fast-check) | [#150](https://github.com/clarkio/wos-plus/issues/150) | ✅ done | PR #159 |
 | 5 — Mutation testing + change-risk | [#154](https://github.com/clarkio/wos-plus/issues/154) | ⬜ not started | — |
@@ -42,12 +42,14 @@ ever disagree, believe `CLAUDE.md`.
 
 ### What to do next, and why
 
-**#155 first.** It is small, and it turns 90.83% from an achievement into a floor
-that cannot silently erode — every PR after it lands against an enforced baseline.
-Suggested thresholds are roughly current-minus-one so ordinary churn does not trip
-them: statements 90, branches 85, functions 86, lines 90.
+**#155 is done.** `vitest.config.ts` now enforces a global floor (statements 90,
+branches 85, functions 86, lines 90) plus per-file floors for `wos-words.ts` and
+`src/lib/**`, with a ratchet-only policy documented in `CLAUDE.md` § 4 and
+`TESTING.md` § Coverage. `pnpm run test:coverage` fails below those numbers —
+verified by temporarily raising a threshold above measured reality and watching
+the run fail, then reverting.
 
-Then the **behaviour issues** below, which include live defects. Then #153 (cheap,
+Next: the **behaviour issues** below, which include live defects. Then #153 (cheap,
 workflow files only), then #154. #152 last or never — `wrangler dev` may not run in
 a sandbox at all.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,12 +152,23 @@ Prefer a failing build over a paragraph of good advice.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
 - Coverage: **90.83% statements / 86.33% branches / 87.79% functions /
   91.56% lines**. It counts **all** files under `src/**/*.ts`, so an untested
-  module appears at 0% instead of being invisible. There are **no coverage
-  thresholds yet** — do not let that absence justify lowering coverage.
+  module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.
   - `src/scripts/wos-widget.ts` is still at **0%** — the one module no test
     imports.
+  - **Thresholds are enforced** (`vitest.config.ts` `coverage.thresholds`,
+    landed with [#155](https://github.com/clarkio/wos-plus/issues/155)):
+    global floor statements 90 / branches 85 / functions 86 / lines 90, plus
+    per-file floors for `src/scripts/wos-words.ts` (96/90/94/98) and
+    `src/lib/**` (86/63/100/91, set by `launch-menu.ts`, the weakest file
+    there — `cors.ts` and `board-utils.ts` are both at 100%). Per-file
+    thresholds apply to each matching file individually, not aggregated.
+    **Ratchet-only policy**: thresholds only go up. A PR that adds code keeps
+    coverage at or above the floor it lands against; lowering a threshold is
+    a deliberate, reviewed act justified in the PR, never a shortcut to green.
+    Quarterly target stays 85/80/85/85 global. Details in
+    [TESTING.md § Coverage](TESTING.md#coverage).
 - ~~Known coverage-tooling gap: the four API routes importing
   `cloudflare:workers` are dropped from coverage.~~ **Fixed** — the specifier is
   aliased to `tests/stubs/cloudflare-workers.ts` in `vitest.config.ts`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -423,16 +423,30 @@ After running `npm run test:coverage`, coverage reports are generated in:
 
 ### Coverage Goals
 
-Aim for:
-- **Statements**: 80%+
-- **Branches**: 75%+
-- **Functions**: 80%+
-- **Lines**: 80%+
-
 Coverage is reported for **every** file under `src/**/*.ts`, including files no
 test imports yet, so an untested module shows up as `0%` rather than
-disappearing from the report. There are **no enforced thresholds** yet — that
-absence is not licence to lower coverage. Current numbers are in `CLAUDE.md` §4.
+disappearing from the report. Current numbers are in `CLAUDE.md` §4.
+
+**Thresholds are enforced in `vitest.config.ts`, not aspirational.**
+`pnpm run test:coverage` fails the build below:
+
+- **Global floor**: statements 90%, branches 85%, functions 86%, lines 90%
+  (set just below the measured baseline so ordinary churn doesn't trip it).
+- **Per-file floors** for the crown jewels, checked against every matching
+  file individually (not aggregated): `src/scripts/wos-words.ts` (statements
+  96%, branches 90%, functions 94%, lines 98%) and `src/lib/**` (statements
+  86%, branches 63%, functions 100%, lines 91% — set by `launch-menu.ts`, the
+  weakest file in that directory).
+
+**Ratchet-only policy**: thresholds only go up. A PR that adds code must keep
+coverage at or above the floor it's landing against; if you land new tests
+that raise real coverage, raise the threshold in the same PR. Lowering a
+threshold is a deliberate, reviewed act — justify it explicitly in the PR
+description, and never do it just to get CI green. The quarterly target
+remains 85/80/85/85 global as coverage continues to climb.
+
+Padding coverage with assertion-free tests to clear a threshold defeats the
+point — see §2 (Agent contract) in `CLAUDE.md`.
 
 ### What to Test
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,36 @@ export default defineConfig({
         '**/*.spec.ts',
         'tests/',
       ],
+
+      // Ratchet-only floor (CLAUDE.md §4 / AGENTIC-TESTING-PLAN.md #155):
+      // set just below the measured baseline so ordinary churn doesn't trip
+      // it, but a real regression fails the build. Raising a threshold is
+      // fine any time; lowering one is a deliberate, reviewed act — never
+      // do it just to get CI green.
+      thresholds: {
+        statements: 90,
+        branches: 85,
+        functions: 86,
+        lines: 90,
+
+        // Per-file floors for the crown jewels, measured at PR #155
+        // (statements/branches/functions/lines: 96.77/91.67/95.24/98.78).
+        'src/scripts/wos-words.ts': {
+          statements: 96,
+          branches: 90,
+          functions: 94,
+          lines: 98,
+        },
+        // Applies per-file, not aggregated: the floor here is set by
+        // launch-menu.ts (86.84/63.64/100/91.67), the weakest file in
+        // src/lib — board-utils.ts and cors.ts are both at 100%.
+        'src/lib/**': {
+          statements: 86,
+          branches: 63,
+          functions: 100,
+          lines: 91,
+        },
+      },
     },
 
     // Test file patterns


### PR DESCRIPTION
## What changed

Implements #155 (Phase 2c of `AGENTIC-TESTING-PLAN.md`): enforced coverage
thresholds with a ratchet-only policy, so 90.83% becomes a floor CI defends
instead of a number in a doc.

- `vitest.config.ts`: `coverage.thresholds` — global floor **statements 90 /
  branches 85 / functions 86 / lines 90**, plus per-file floors for
  `src/scripts/wos-words.ts` (96/90/94/98) and `src/lib/**` (86/63/100/91 —
  set by `launch-menu.ts`, the weakest file there; `cors.ts` and
  `board-utils.ts` are both at 100%). All set just below the measured
  baseline of **90.83% statements / 86.33% branches / 87.79% functions /
  91.56% lines** (636 passing tests, 19 files, 8 `it.todo`).
- `CLAUDE.md` §4 and `TESTING.md` § Coverage: document the enforced numbers
  and the ratchet-only policy — thresholds only go up; lowering one is a
  deliberate, reviewed act, justified in the PR, never a shortcut to green.
  `TESTING.md`'s stale, unenforced 80/75/80/80 "Coverage Goals" section is
  replaced with the real, enforced numbers.
- `AGENTIC-TESTING-PLAN.md`: marks Phase 2c / #155 done in the status table
  and "what to do next" section.

**Measured coverage (unchanged by this PR — no new tests, per the issue's
"out of scope" note):**

```
Statements   : 90.83% ( 1051/1157 )
Branches     : 86.33% ( 556/644 )
Functions    : 87.79% ( 151/172 )
Lines        : 91.56% ( 999/1091 )
```

**Enforcement verified, not assumed**: temporarily raised the global
`statements` threshold to 99 and confirmed `pnpm run test:coverage` failed
with `ERROR: Coverage for statements (90.83%) does not meet global threshold
(99%)` and a non-zero exit code, then reverted to the real value (90) and
confirmed it passes again.

## Verification

- [x] Spec in `specs/` added or updated — N/A, this is tooling/gate work, not
      a behavior change
- [x] Tests written or updated *before or with* the implementation — N/A, no
      new tests; this PR adds an enforcement gate on existing measured
      coverage, per the issue's explicit "out of scope: do not write new
      tests to hit a number"
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

- Per-file thresholds in Vitest apply to **each matching file individually**,
  not aggregated — so `src/lib/**` had to be floored at the level of its
  weakest file (`launch-menu.ts`, 86.84/63.64/100/91.67) rather than the
  directory's blended average (94.44/87.87/100/96.59). `cors.ts` and
  `board-utils.ts` clear the floor trivially since they're both at 100%.
- `src/scripts/wos-widget.ts` remains at 0% (no test imports it) and is
  covered by the global floor rather than a per-file one, consistent with
  the existing known gap noted in `CLAUDE.md` §4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZLV5nT9CujQAZF7Dg3AKD)_