### PR TITLE
Keep the daily badges sticky across a failed chatbot-status refresh (#170)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -30,10 +30,10 @@ describe intent, not status. This section is the status.
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
 
-### The numbers, as of PR #175
+### The numbers, as of the #170 fix
 
-**636 passing** tests across 19 files, plus 8 deliberate `it.todo`. Coverage
-**90.83% statements / 86.33% branches / 87.79% functions / 91.56% lines**, counting
+**643 passing** tests across 19 files, plus 7 deliberate `it.todo`. Coverage
+**90.91% statements / 86.62% branches / 87.86% functions / 91.64% lines**, counting
 every file under `src/**/*.ts` so an untested module shows as 0% rather than being
 invisible. `src/scripts/wos-widget.ts` is the one module no test imports.
 
@@ -60,8 +60,10 @@ Playwright and #154 adds StrykerJS.
 
 Thirteen issues, all approved by the maintainer:
 [#161](https://github.com/clarkio/wos-plus/issues/161)–[#173](https://github.com/clarkio/wos-plus/issues/173).
-**[#173](https://github.com/clarkio/wos-plus/issues/173) is done** (PR
-[#176](https://github.com/clarkio/wos-plus/pull/176)) — twelve remain.
+**[#173](https://github.com/clarkio/wos-plus/issues/173) and
+[#170](https://github.com/clarkio/wos-plus/issues/170) are done** (PR
+[#176](https://github.com/clarkio/wos-plus/pull/176) and the #170 fix) —
+eleven remain.
 
 Each open one has a ⚠️ scenario in `specs/` and an acceptance test **pinning
 current behaviour** under the name `known gap (#N)`. That is the mechanism to
@@ -74,9 +76,22 @@ genuine "no rows yet" (`PGRST116`) and answers a failure rather than
 fabricating a 200 with zeros, and the `known gap (#173)` canary in
 `channel-stats.acceptance.test.ts` was inverted, not deleted.
 
+#170 shows a variant of the pattern worth knowing before touching a similar
+issue: the defect turned out to be entirely in the **view** layer
+(`GameSpectator.refreshChannelStats()` in `src/scripts/wos-plus-main.ts`),
+not the route. The route's per-request `chatbotEnabled: false` fail-closed
+answer on a genuine read error was already correct and stays unchanged — only
+the client's handling of that answer needed to become sticky (`chatbotEnabled`
+now only ever turns on, mirroring how the three numbers only ever rise). The
+route-level `known gap (#170)` acceptance test was reframed as confirmed
+rather than inverted in place, because the value it pins never changes; the
+real fix is proven by a new test in `tests/unit/wos-plus-main.test.ts` §
+`refreshChannelStats`. See `specs/channel-stats.md` § "a temporary failure
+does not hide the daily badges" for the full reasoning.
+
 Sharpest next, affecting streamers today:
 
-- [#170](https://github.com/clarkio/wos-plus/issues/170) — the daily badges vanish on a blip, because `chatbotEnabled` is not protected from a failed refresh the way the three numbers are. Same defect class as #173; the client-side half (`wos-plus-main.ts`) is out of scope for #173's own fix, deliberately.
+- [#166](https://github.com/clarkio/wos-plus/issues/166) — WoS+ ignores the all-time record the game reports on connect and shows only the stored value, so a channel's real history can lag behind what the game itself knows.
 
 **Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165) overlaps open PR #142, and [#167](https://github.com/clarkio/wos-plus/issues/167) overlaps open PR #144. For #144 especially — recording a slot as solved *without* also blocking the board save would put an unknown word into the archive, the exact failure #167 rules out.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Prefer a failing build over a paragraph of good advice.
 
 ## 4. Known state (keep current)
 
-- Test suite: **636 passing** Vitest tests across 19 files, plus **8
+- Test suite: **643 passing** Vitest tests across 19 files, plus **7
   `it.todo`**. Every remaining todo is a **known gap with a tracking issue or a
   stated coverage limitation** — none is simply an unwritten test, and none may
   be deleted to tidy the count. The decisions behind them are tabulated in
@@ -150,8 +150,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **90.83% statements / 86.33% branches / 87.79% functions /
-  91.56% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **90.91% statements / 86.62% branches / 87.86% functions /
+  91.64% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/specs/README.md
+++ b/specs/README.md
@@ -141,7 +141,6 @@ behaviour, so implementing one forces its test to be inverted deliberately.
 | G3 | The 12-letter chat filter is correct and stays; the **board name rule comes down** from 20 to 12 to match it. Longest word in the shared list is 8, so 12 is the cushion. | [#168](https://github.com/clarkio/wos-plus/issues/168) |
 | *new* | A board's words must all be spellable from its big word's letters; one that is not makes the board **broken and repairable**. | [#163](https://github.com/clarkio/wos-plus/issues/163) |
 | *new* | A board is saved only with a **supplied, supported** word language — no more substituting English. | [#161](https://github.com/clarkio/wos-plus/issues/161) |
-| C2 | The daily badges follow the chatbot **grant**. A failed read must not hide them — it has discovered nothing, not that the channel lost the chatbot. | [#170](https://github.com/clarkio/wos-plus/issues/170) |
 | W1 | The client-side word-adding path is **retired**. New words are derived from boards, in the database layer, as part of the board save flow. Reading the list is untouched. | [#171](https://github.com/clarkio/wos-plus/issues/171) |
 | G6 | On reconnect, rebuild the found-words list from the re-reported slots **only on a level with no masked guesses**. On a masked level the gap stays — a masked guess cannot be recovered after the fact. | [#169](https://github.com/clarkio/wos-plus/issues/169) |
 
@@ -156,6 +155,7 @@ recorded in the spec so these are not raised again.
 | G1 | Masking begins at **level 19 and above**. This is the *game's* threshold; WoS+ enforces none, branching only on `?` in the word — so if Words on Stream moves it, WoS+ keeps working and only the spec line changes. |
 | W2 | Excluding a never-revealed hidden letter from missed-word suggestions is correct. **Hidden letters are always eventually revealed** by a specific game event, so a still-masked tile at that point is not the normal end state. |
 | W3 | Missed words stay matched to the archived board **by slot position**. The repair path is what handles a stored board that disagrees with the game, rather than working around it at read time. |
+| ~~C2~~ | ~~The daily badges follow the chatbot **grant**. A failed read must not hide them — it has discovered nothing, not that the channel lost the chatbot.~~ **Fixed** — `GameSpectator.refreshChannelStats()` now only ever turns `chatbotEnabled` on, mirroring the three numbers; the route's own per-request fail-closed answer is unchanged and still correct. Per [#170](https://github.com/clarkio/wos-plus/issues/170). |
 
 Two answers cross-check each other and are worth reading together: **C3** (the
 game wins on connect) and **G5** (the chatbot wins during play). The maintainer

--- a/specs/channel-stats.md
+++ b/specs/channel-stats.md
@@ -252,17 +252,14 @@ case it is typed in.
   for a moment and come back. A failed read has not discovered that the channel
   lost the chatbot; it has discovered nothing at all.
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today reports the channel as not
-> having the chatbot when the read fails, and the badges disappear until a later
-> refresh succeeds. The three numbers are already protected from a failed
-> refresh; whether the channel has the chatbot is not. Tracked by
-> [#170](https://github.com/clarkio/wos-plus/issues/170).
->
-> A later answer in the same review sharpens it. Having the chatbot is
-> **granted**, not detected — set by hand today, intended to become a paid
-> opt-in (see [README.md](README.md#which-channels-have-the-chatbot)). A grant
-> does not lapse for a moment and come back. So a failed read reporting "this
-> channel has no chatbot" is not a stale answer, it is a wrong one, and the
-> badges disappear on the strength of it. That makes the case for treating
-> `chatbotEnabled` like the three numbers — protected from a failed refresh —
-> but it is still the maintainer's call, so the marker stays.
+> ✅ **Confirmed (maintainer)**, fixed by
+> [#170](https://github.com/clarkio/wos-plus/issues/170). This is view
+> behaviour, not route behaviour: `/api/channel-stats/[channel]` still
+> correctly fails closed to `chatbotEnabled: false` on any one request where it
+> can't tell (see § "whether the channel has the chatbot cannot be determined"
+> above — that per-request answer is unchanged and still right). The fix is in
+> `GameSpectator.refreshChannelStats()` (`src/scripts/wos-plus-main.ts`): once a
+> refresh has reported the chatbot as enabled, `chatbotEnabled` only ever turns
+> on, the same way the three numbers only ever rise — a later refresh reporting
+> `false` (whether from a real change or, far more likely, a transient read
+> failure the route can't tell apart from "no chatbot") no longer overwrites it.

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -122,7 +122,12 @@ export class GameSpectator {
     this.personalBest = Math.max(this.personalBest, stats.allTimePersonalBest);
     this.dailyBest = Math.max(this.dailyBest, stats.dailyBest);
     this.dailyClears = Math.max(this.dailyClears, stats.dailyClears);
-    this.chatbotEnabled = stats.chatbotEnabled;
+    // Having the chatbot is a grant, not something detected per-request (issue
+    // #170): once a refresh has confirmed it, a later refresh reporting
+    // "disabled" has discovered nothing — most likely a failed or ambiguous
+    // read that fails closed to false — rather than that the channel lost the
+    // chatbot. So this only ever turns on, mirroring the numbers above.
+    this.chatbotEnabled = this.chatbotEnabled || stats.chatbotEnabled;
     this.updateStatsDisplay();
   }
 

--- a/tests/acceptance/channel-stats.acceptance.test.ts
+++ b/tests/acceptance/channel-stats.acceptance.test.ts
@@ -770,11 +770,11 @@ describe("specs/channel-stats.md — Reading a channel's records", () => {
 // specs/channel-stats.md § Open questions for the maintainer
 // ===========================================================================
 
-describe('specs/channel-stats.md — approved changes not yet implemented, and one still-open question', () => {
+describe('specs/channel-stats.md — approved changes, some still not implemented', () => {
   /**
-   * Mixed block, deliberately. Two of these were answered by the maintainer in
-   * review of PR #160 and are now **known gaps** with issues; one is still an
-   * open question.
+   * Mixed block, deliberately. One of these was answered by the maintainer in
+   * review of PR #160 and is still a **known gap** with an issue; the #170
+   * scenario below has since been resolved and is confirmed, not a gap.
    *
    * Every assertion pins what the code does **today**. None is approved
    * contract, and none may be deleted to make an implementation pass — per
@@ -821,24 +821,24 @@ describe('specs/channel-stats.md — approved changes not yet implemented, and o
     });
   });
 
-  describe('Scenario: a temporary failure hides the daily badges', () => {
+  describe('Scenario: a temporary failure does not hide the daily badges (#170, resolved)', () => {
     // Given WoS+ is connected to a channel that has the chatbot, and the daily
     //       badges are visible
     // And the channel records briefly cannot be reached
     // When a refresh is attempted
-    // Then the numbers stay as they were, but the daily badges disappear until a
-    //      later refresh succeeds
+    // Then the numbers stay as they were and the daily badges stay visible
     //
-    // ❓ Unconfirmed. The route's half is pinned below; the view's half — that
-    // the badges then vanish mid-stream — lives in `src/scripts/wos-plus-main.ts`
-    // and belongs with the game-flow work.
+    // ✅ Confirmed (maintainer), fixed by #170 — see specs/channel-stats.md §
+    // "a temporary failure does not hide the daily badges". This is view
+    // behaviour, not route behaviour: the route's per-request answer below is
+    // unchanged and still correct (same mechanism as "whether the channel has
+    // the chatbot cannot be determined" above). The fix is that
+    // `GameSpectator.refreshChannelStats()` in `src/scripts/wos-plus-main.ts`
+    // now only ever turns `chatbotEnabled` on, so a later blip reporting
+    // `false` no longer overwrites a grant it already observed — see
+    // `tests/unit/wos-plus-main.test.ts` § refreshChannelStats.
 
-    it('known gap (#170): reports the chatbot as disabled on a blip, even for a channel that has it', async () => {
-      // Same mechanism as "whether the channel has the chatbot cannot be
-      // determined", which the spec *does* confirm. What is unconfirmed is the
-      // consequence: that a one-off failure is indistinguishable from a channel
-      // genuinely without the chatbot, so a transient error hides badges that
-      // were legitimately on screen a second ago.
+    it('still fails closed to chatbotEnabled: false on a single request, even though the numbers survive the blip', async () => {
       archiveHas({
         allTime: allTimeRow(42),
         daily: dailyRow(30, 3),
@@ -854,21 +854,11 @@ describe('specs/channel-stats.md — approved changes not yet implemented, and o
       });
 
       expect(await readJson(response)).toMatchObject({
-        // The numbers survive the blip …
         dailyBest: 30,
         dailyClears: 3,
-        // … but the flag that decides whether they are shown does not.
         chatbotEnabled: false,
       });
     });
-
-    it.todo(
-      'known gap (#170): a transient failure must not hide the daily badges — the ' +
-      'maintainer ruled the badges follow the chatbot GRANT, and a grant does not lapse ' +
-      'for a moment and come back, so chatbotEnabled must be sticky across a failed ' +
-      'refresh the way the three numbers already are. The view half lives in ' +
-      'src/scripts/wos-plus-main.ts (specs/channel-stats.md § Showing the records on screen)',
-    );
   });
 
   describe('Scenario: the all-time best the game itself reports', () => {

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -289,6 +289,61 @@ describe('GameSpectator class', () => {
     });
   });
 
+  describe('refreshChannelStats', () => {
+    beforeEach(() => {
+      spectator = new GameSpectator();
+      spectator.currentChannel = 'testchannel';
+    });
+
+    it('keeps the daily badges visible across a refresh that reports the chatbot as disabled (issue #170)', async () => {
+      // Having the chatbot is a grant, not something detected per-request — a
+      // read that comes back saying "not enabled" after one already reported
+      // "enabled" has discovered nothing, not that the channel lost the
+      // chatbot (specs/channel-stats.md § Showing the records on screen).
+      spectator.chatbotEnabled = true;
+
+      vi.mocked(fetchChannelStats).mockResolvedValueOnce({
+        allTimePersonalBest: 42,
+        dailyBest: 30,
+        dailyClears: 3,
+        chatbotEnabled: false,
+      });
+
+      await (spectator as any).refreshChannelStats();
+
+      expect(spectator.chatbotEnabled).toBe(true);
+      expect(document.getElementById('daily-pb-record')!.style.display).toBe('');
+      expect(document.getElementById('daily-clear-record')!.style.display).toBe('');
+    });
+
+    it('turns the daily badges on once a refresh reports the chatbot as enabled', async () => {
+      spectator.chatbotEnabled = false;
+
+      vi.mocked(fetchChannelStats).mockResolvedValueOnce({
+        allTimePersonalBest: 42,
+        dailyBest: 30,
+        dailyClears: 3,
+        chatbotEnabled: true,
+      });
+
+      await (spectator as any).refreshChannelStats();
+
+      expect(spectator.chatbotEnabled).toBe(true);
+      expect(document.getElementById('daily-pb-record')!.style.display).toBe('');
+      expect(document.getElementById('daily-clear-record')!.style.display).toBe('');
+    });
+
+    it('does nothing when no channel is connected', async () => {
+      spectator.currentChannel = '';
+      spectator.chatbotEnabled = true;
+
+      await (spectator as any).refreshChannelStats();
+
+      expect(fetchChannelStats).not.toHaveBeenCalled();
+      expect(spectator.chatbotEnabled).toBe(true);
+    });
+  });
+
   describe('clearBoard', () => {
     beforeEach(() => {
       spectator = new GameSpectator();


### PR DESCRIPTION
## What changed

Fixes [#170](https://github.com/clarkio/wos-plus/issues/170), the sharpest item in the `AGENTIC-TESTING-PLAN.md` behaviour backlog. Having the chatbot is a **grant**, not something detected per-request. A transient failure reading the `users` table made `GameSpectator.refreshChannelStats()` (`src/scripts/wos-plus-main.ts`) overwrite an already-confirmed `chatbotEnabled = true` with `false`, hiding the daily badges until a later refresh happened to succeed. `chatbotEnabled` now only ever turns **on** during a refresh, the same way the three record numbers only ever rise.

The route's own per-request answer (`/api/channel-stats/[channel]`) is unchanged and still correct — a single request legitimately fails closed to `chatbotEnabled: false` when it can't tell. So the route-level acceptance test that used to pin this as a `known gap (#170)` is reframed as confirmed rather than inverted, since the value it asserts never actually changes; the real fix is proven by a new `refreshChannelStats` suite in `tests/unit/wos-plus-main.test.ts`.

## Verification

- [x] Spec in `specs/` added or updated — `specs/channel-stats.md` § "a temporary failure does not hide the daily badges" moved from ⚠️ Approved to ✅ Confirmed; `specs/README.md` § Decisions from the #160 review moved C2 to the fixed/confirmed table.
- [x] Tests written before the implementation — added three failing tests in `tests/unit/wos-plus-main.test.ts` § `refreshChannelStats`, confirmed one failed against the old code, then made the fix.
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally:
  - `check`: 0 errors, 0 warnings, 15 hints (unchanged, pre-existing)
  - `lint`: clean, 0 warnings
  - `test:coverage`: 643 passed, 7 todo (was 636 passed, 8 todo). Coverage 90.91% stmts / 86.62% branches / 87.86% funcs / 91.64% lines — above all thresholds
  - `build`: succeeds
- [x] No existing test weakened, skipped, or deleted — the route-level test that used to be `it('known gap (#170): ...')` is kept with the same assertion, just reframed as confirmed (its value doesn't change); the paired `it.todo` for the view half is replaced by a real, passing test suite in `wos-plus-main.test.ts`.
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

This turned out to be entirely a view-layer fix, not a route fix — worth flagging since the acceptance-test framing initially suggested the route needed to change too. `AGENTIC-TESTING-PLAN.md` § "What to do next, and why" is updated to record that distinction for the next agent picking up a similar issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuY3KKyd83dYQd7kUABnip)_