### PR TITLE
Show the game's reported all-time record on connect, display-only (#166)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -30,10 +30,10 @@ describe intent, not status. This section is the status.
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
 
-### The numbers, as of the #170 fix
+### The numbers, as of the #166 fix
 
-**643 passing** tests across 19 files, plus 7 deliberate `it.todo`. Coverage
-**90.91% statements / 86.62% branches / 87.86% functions / 91.64% lines**, counting
+**645 passing** tests across 19 files, plus 6 deliberate `it.todo`. Coverage
+**90.94% statements / 86.70% branches / 87.86% functions / 91.66% lines**, counting
 every file under `src/**/*.ts` so an untested module shows as 0% rather than being
 invisible. `src/scripts/wos-widget.ts` is the one module no test imports.
 
@@ -60,10 +60,11 @@ Playwright and #154 adds StrykerJS.
 
 Thirteen issues, all approved by the maintainer:
 [#161](https://github.com/clarkio/wos-plus/issues/161)–[#173](https://github.com/clarkio/wos-plus/issues/173).
-**[#173](https://github.com/clarkio/wos-plus/issues/173) and
-[#170](https://github.com/clarkio/wos-plus/issues/170) are done** (PR
-[#176](https://github.com/clarkio/wos-plus/pull/176) and the #170 fix) —
-eleven remain.
+**[#173](https://github.com/clarkio/wos-plus/issues/173),
+[#170](https://github.com/clarkio/wos-plus/issues/170) and
+[#166](https://github.com/clarkio/wos-plus/issues/166) are done** (PR
+[#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix and the
+#166 fix) — ten remain.
 
 Each open one has a ⚠️ scenario in `specs/` and an acceptance test **pinning
 current behaviour** under the name `known gap (#N)`. That is the mechanism to
@@ -89,9 +90,25 @@ real fix is proven by a new test in `tests/unit/wos-plus-main.test.ts` §
 `refreshChannelStats`. See `specs/channel-stats.md` § "a temporary failure
 does not hide the daily badges" for the full reasoning.
 
-Sharpest next, affecting streamers today:
+#166 (all-time best follows the game's reported record on connect) narrowed in
+scope during implementation, worth knowing before assuming an issue's text is
+the final word: the original text called for WoS+ to write the game's record
+back to `wos_channel_all_time_records`, but that would have been a new,
+unauthenticated write path — an architecture-tier change under `CLAUDE.md` §5
+that needs sign-off regardless of confidence, and it opened a spoofing
+question (any client could claim a fabricated record). Asked directly, the
+maintainer confirmed no write-back is needed at all: the chatbot already keeps
+the table in sync for channels that have it, and nothing has ever written it
+for channels that don't, so the fix is purely a display update in
+`GameSpectator`'s Game Connected handler. Proven by a new test in
+`tests/unit/wos-plus-main.test.ts` § "worker routing (startEventProcessors)".
 
-- [#166](https://github.com/clarkio/wos-plus/issues/166) — WoS+ ignores the all-time record the game reports on connect and shows only the stored value, so a channel's real history can lag behind what the game itself knows.
+Sharpest next, affecting streamers today: none of the remaining ten are
+flagged as urgent on their own — [#165](https://github.com/clarkio/wos-plus/issues/165)
+and [#167](https://github.com/clarkio/wos-plus/issues/167) overlap open PRs
+(see below), and [#164](https://github.com/clarkio/wos-plus/issues/164) (leading
+`#` stripped on the stats path) is the smallest, cleanest remaining pick with no
+overlap and no architecture question.
 
 **Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165) overlaps open PR #142, and [#167](https://github.com/clarkio/wos-plus/issues/167) overlaps open PR #144. For #144 especially — recording a slot as solved *without* also blocking the board save would put an unknown word into the archive, the exact failure #167 rules out.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Prefer a failing build over a paragraph of good advice.
 
 ## 4. Known state (keep current)
 
-- Test suite: **643 passing** Vitest tests across 19 files, plus **7
+- Test suite: **645 passing** Vitest tests across 19 files, plus **6
   `it.todo`**. Every remaining todo is a **known gap with a tracking issue or a
   stated coverage limitation** — none is simply an unwritten test, and none may
   be deleted to tidy the count. The decisions behind them are tabulated in
@@ -150,8 +150,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **90.91% statements / 86.62% branches / 87.86% functions /
-  91.64% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **90.94% statements / 86.70% branches / 87.86% functions /
+  91.66% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/specs/README.md
+++ b/specs/README.md
@@ -136,7 +136,6 @@ behaviour, so implementing one forces its test to be inverted deliberately.
 | B1, B2 | The board **save** path must apply the same name, slot and completeness guards as lookup and repair. Today it applies only the repeated-word rule. | [#162](https://github.com/clarkio/wos-plus/issues/162) |
 | B3 | A board is filed under the **longest** word on it, alphabetically last among ties — not the last slot's word. | [#165](https://github.com/clarkio/wos-plus/issues/165) |
 | C1 | A leading `#` is **always** stripped, on the stats path as well as the board path. | [#164](https://github.com/clarkio/wos-plus/issues/164) |
-| C3 | The record level the game reports **on connect** wins over the stored value, and the stored record is updated. All-time best only. | [#166](https://github.com/clarkio/wos-plus/issues/166) |
 | G2 | An unrecoverable masked guess **counts as a clear**, but **blocks the board save**. Two outcomes, deliberately decoupled. | [#167](https://github.com/clarkio/wos-plus/issues/167) |
 | G3 | The 12-letter chat filter is correct and stays; the **board name rule comes down** from 20 to 12 to match it. Longest word in the shared list is 8, so 12 is the cushion. | [#168](https://github.com/clarkio/wos-plus/issues/168) |
 | *new* | A board's words must all be spellable from its big word's letters; one that is not makes the board **broken and repairable**. | [#163](https://github.com/clarkio/wos-plus/issues/163) |
@@ -156,6 +155,7 @@ recorded in the spec so these are not raised again.
 | W2 | Excluding a never-revealed hidden letter from missed-word suggestions is correct. **Hidden letters are always eventually revealed** by a specific game event, so a still-masked tile at that point is not the normal end state. |
 | W3 | Missed words stay matched to the archived board **by slot position**. The repair path is what handles a stored board that disagrees with the game, rather than working around it at read time. |
 | ~~C2~~ | ~~The daily badges follow the chatbot **grant**. A failed read must not hide them — it has discovered nothing, not that the channel lost the chatbot.~~ **Fixed** — `GameSpectator.refreshChannelStats()` now only ever turns `chatbotEnabled` on, mirroring the three numbers; the route's own per-request fail-closed answer is unchanged and still correct. Per [#170](https://github.com/clarkio/wos-plus/issues/170). |
+| ~~C3~~ | ~~The record level the game reports **on connect** wins over the stored value, and the stored record is updated.~~ **Fixed, scope narrowed** — display-only in `GameSpectator`'s Game Connected handler; WoS+ never writes the record back itself. The chatbot already keeps the stored value in sync for channels that have it, and nothing has ever written it for channels that don't, so there was no write-back left to build — a client-writable stats endpoint would also have been an unauthenticated write path. Per [#166](https://github.com/clarkio/wos-plus/issues/166). |
 
 Two answers cross-check each other and are worth reading together: **C3** (the
 game wins on connect) and **G5** (the chatbot wins during play). The maintainer

--- a/specs/channel-stats.md
+++ b/specs/channel-stats.md
@@ -222,19 +222,28 @@ case it is typed in.
 - **Given** WoS+ connects to a running game that reports the channel's record
   level
 - **When** the connection is made
-- **Then** that number is taken as the truth for the all-time best, and the
-  stored channel record is brought up to date to match it
+- **Then** that number is shown as the all-time best, taking priority over
+  whatever was previously on screen
 
   The game holds the real history; WoS+'s copy is a cache of it. This applies to
   the **all-time best only** — daily best and daily clears still come from the
   chatbot and are not touched.
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today ignores the record the game
-> sends on connect and shows only the stored value. Tracked by
-> [#166](https://github.com/clarkio/wos-plus/issues/166).
+> ✅ **Confirmed (maintainer)**, fixed by
+> [#166](https://github.com/clarkio/wos-plus/issues/166). Display-only, in
+> `GameSpectator`'s Game Connected handler (`src/scripts/wos-plus-main.ts`) —
+> WoS+ never writes this back to the database itself. The maintainer narrowed
+> the scope when implementation started: for a channel that has the chatbot,
+> the chatbot is what keeps `wos_channel_all_time_records` in sync, so there is
+> nothing for WoS+ to write; for a channel without it, nothing has ever written
+> that table and this change doesn't start now — WoS+ just shows the number the
+> game reports. A client-writable stats endpoint would also have been a new,
+> unauthenticated write path (anyone could inflate a channel's record), which
+> is exactly the kind of architecture change `CLAUDE.md` §5 gates behind
+> explicit sign-off; it turned out not to be needed at all.
 >
-> ✅ The distinction is **when**, confirmed by the maintainer. This sits
-> deliberately alongside the chatbot-lag rule in
+> ✅ The distinction from the chatbot-lag rule is **when**, confirmed by the
+> maintainer. This sits deliberately alongside that rule in
 > [game-flow.md](game-flow.md): **on connect** the game reports a historical
 > record and wins; **during play** a level just reached waits for the chatbot
 > rather than being applied optimistically. The two answers do not conflict —

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -216,7 +216,7 @@ export class GameSpectator {
     // Set up WOS worker message handler
     wosWorker.onmessage = async (e) => {
       if (e.data.type === 'wos_event') {
-        const { wosEventType, wosEventName, username, letters, hitMax, stars, level, falseLetters, hiddenLetters, slots, index, language } = e.data;
+        const { wosEventType, wosEventName, username, letters, hitMax, stars, level, record, falseLetters, hiddenLetters, slots, index, language } = e.data;
 
         const message = username ? `:${username} - ${letters.join('')} - Big Word: ${hitMax}` : '';
         console.log(`[WOS Event] <${wosEventName}>${message}`);
@@ -232,6 +232,16 @@ export class GameSpectator {
 
         if (wosEventType === 1 || wosEventType === 12) {
           this.handleGameInitialization(level, wosEventType, letters, slots);
+          if (wosEventType === 12 && typeof record === 'number') {
+            // The game holds the real history for the all-time best; WoS+'s
+            // stored copy is only a cache of it, so on connect the game's
+            // reported record wins over whatever is currently shown (issue
+            // #166). This is a display-only update — WoS+ never writes it
+            // back to the database; the chatbot is what keeps the stored
+            // record in sync for channels that have it.
+            this.personalBest = record;
+            this.updateStatsDisplay();
+          }
           await this.refreshChannelStats();
         } else if (wosEventType === 3) {
           await this.handleCorrectGuess(username, letters, index, hitMax);

--- a/tests/acceptance/channel-stats.acceptance.test.ts
+++ b/tests/acceptance/channel-stats.acceptance.test.ts
@@ -861,24 +861,20 @@ describe('specs/channel-stats.md — approved changes, some still not implemente
     });
   });
 
-  describe('Scenario: the all-time best the game itself reports', () => {
-    // Given WoS+ connects to a running game that reports the channel's record level
-    // When the connection is made
-    // Then that number is ignored, and the all-time best shown comes only from
-    //      the stored channel records
-    //
-    // Nothing in this route can see the game's connection payload, so there is
-    // no route-level half to pin. Recorded here because the question belongs to
-    // this spec file.
-
-    it.todo(
-      'known gap (#166): the record level on the game connection payload is ignored — ' +
-      'the maintainer ruled the game is the source of truth for the all-time best on ' +
-      'connect, and the stored record should be updated to match. The code comment ' +
-      'saying so was right; nothing read the value. Lives in src/scripts/wos-plus-main.ts ' +
-      '(specs/channel-stats.md § Approved, not yet implemented)',
-    );
-  });
+  // Scenario: the all-time best the game itself reports (#166, resolved)
+  //
+  // Given WoS+ connects to a running game that reports the channel's record level
+  // When the connection is made
+  // Then that number is shown as the all-time best, taking priority over
+  //      whatever was previously on screen
+  //
+  // ✅ Confirmed (maintainer), fixed by #166 — display-only, in
+  // `GameSpectator`'s Game Connected handler. Nothing in this route can see
+  // the game's connection payload, so there is no route-level half to pin;
+  // the real test lives in `tests/unit/wos-plus-main.test.ts` §
+  // "worker routing (startEventProcessors)". See specs/channel-stats.md §
+  // "the all-time best the game itself reports" for why this turned out not
+  // to need a write-back path at all.
 });
 
 // ===========================================================================

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -1389,6 +1389,62 @@ describe('GameSpectator class', () => {
       expect(document.getElementById('level-value')!.innerText).toBe('5');
     });
 
+    it('should honor the record the game reports on connect as the all-time best (issue #166)', async () => {
+      // The game holds the real history for the all-time best; WoS+'s stored
+      // copy is only a cache of it. On connect the game's reported record
+      // wins, purely in the UI — WoS+ never writes it back to the database
+      // (the chatbot is responsible for that on channels that have it).
+      const wosWorker = findWorkerByUrlSubstring('wos-worker');
+      expect(wosWorker).toBeTruthy();
+
+      spectator.currentChannel = 'testchannel';
+      spectator.personalBest = 3;
+
+      await wosWorker.emitMessage({
+        type: 'wos_event',
+        wosEventType: 12,
+        wosEventName: 'Game Connected',
+        username: '',
+        letters: ['a', 'b', 'c'],
+        hitMax: false,
+        stars: 0,
+        level: 5,
+        record: 47,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: [],
+        index: 0,
+      });
+
+      expect(spectator.personalBest).toBe(47);
+      expect(document.getElementById('pb-value')!.innerText).toBe('47');
+    });
+
+    it('should leave the all-time best alone when a Game Connected event carries no record', async () => {
+      const wosWorker = findWorkerByUrlSubstring('wos-worker');
+      expect(wosWorker).toBeTruthy();
+
+      spectator.currentChannel = 'testchannel';
+      spectator.personalBest = 12;
+
+      await wosWorker.emitMessage({
+        type: 'wos_event',
+        wosEventType: 12,
+        wosEventName: 'Game Connected',
+        username: '',
+        letters: ['a', 'b', 'c'],
+        hitMax: false,
+        stars: 0,
+        level: 5,
+        falseLetters: [],
+        hiddenLetters: [],
+        slots: [],
+        index: 0,
+      });
+
+      expect(spectator.personalBest).toBe(12);
+    });
+
     it('should route wos letter reveal events to update displays', async () => {
       const wosWorker = findWorkerByUrlSubstring('wos-worker');
       expect(wosWorker).toBeTruthy();


### PR DESCRIPTION
## What changed

Fixes [#166](https://github.com/clarkio/wos-plus/issues/166) from the `AGENTIC-TESTING-PLAN.md` behaviour backlog. The Words on Stream game holds the real history for a channel's all-time best; WoS+'s stored copy is only a cache of it. `GameSpectator`'s Game Connected handler (`wosEventType === 12` in `src/scripts/wos-plus-main.ts`) now reads the `record` the game reports on connect and shows it immediately as the all-time best, taking priority over whatever was already on screen.

**Scope narrowed from the original issue text during implementation** — worth flagging explicitly. The issue as written called for WoS+ to also write the game's record back to `wos_channel_all_time_records`. That would have been a new, unauthenticated write path from the client (today only the chatbot writes that table, and the read API is public) — an architecture-tier change `CLAUDE.md` §5 gates behind explicit sign-off regardless of confidence, and it raised a real spoofing question (any client could claim a fabricated record for a channel). I asked the maintainer directly before implementing rather than guess; the answer was that no write-back is needed at all: the chatbot already keeps the table in sync for channels that have the chatbot, and nothing has ever written it for channels that don't — so WoS+ just needs to show the number, never persist it. `specs/channel-stats.md` § "the all-time best the game itself reports" and `specs/README.md`'s C3 row record the reasoning.

## Verification

- [x] Spec in `specs/` added or updated — `specs/channel-stats.md` § "the all-time best the game itself reports" moved from ⚠️ Approved to ✅ Confirmed with the narrowed scope; `specs/README.md` § Decisions from the #160 review moved C3 to the fixed/confirmed table.
- [x] Tests written before the implementation — added two failing tests in `tests/unit/wos-plus-main.test.ts` § "worker routing (startEventProcessors)" (record wins on connect; no record leaves the value alone), confirmed the first failed against the old code, then made the fix.
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally:
  - `check`: 0 errors, 0 warnings, 15 hints (unchanged, pre-existing)
  - `lint`: clean, 0 warnings
  - `test:coverage`: 645 passed, 6 todo (was 643 passed, 7 todo). Coverage 90.94% stmts / 86.70% branches / 87.86% funcs / 91.66% lines — above all thresholds
  - `build`: succeeds
- [x] No existing test weakened, skipped, or deleted — the acceptance-test `it.todo(#166: ...)` placeholder for the view half is replaced by real, passing tests in `wos-plus-main.test.ts`; nothing else changed.
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

The scope-narrowing above is the main thing to sanity-check — please confirm the "chatbot already handles the write for channels that have it, nothing ever wrote it for channels that don't, so no write-back is needed" reasoning matches your intent from the original issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuY3KKyd83dYQd7kUABnip)_