### PR TITLE
Strip a leading # from channel names in the stats route (#164)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -61,10 +61,11 @@ Playwright and #154 adds StrykerJS.
 Thirteen issues, all approved by the maintainer:
 [#161](https://github.com/clarkio/wos-plus/issues/161)–[#173](https://github.com/clarkio/wos-plus/issues/173).
 **[#173](https://github.com/clarkio/wos-plus/issues/173),
-[#170](https://github.com/clarkio/wos-plus/issues/170) and
-[#166](https://github.com/clarkio/wos-plus/issues/166) are done** (PR
-[#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix and the
-#166 fix) — ten remain.
+[#170](https://github.com/clarkio/wos-plus/issues/170),
+[#166](https://github.com/clarkio/wos-plus/issues/166) and
+[#164](https://github.com/clarkio/wos-plus/issues/164) are done** (PR
+[#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix, the
+#166 fix and the #164 fix) — nine remain.
 
 Each open one has a ⚠️ scenario in `specs/` and an acceptance test **pinning
 current behaviour** under the name `known gap (#N)`. That is the mechanism to
@@ -103,12 +104,13 @@ for channels that don't, so the fix is purely a display update in
 `GameSpectator`'s Game Connected handler. Proven by a new test in
 `tests/unit/wos-plus-main.test.ts` § "worker routing (startEventProcessors)".
 
-Sharpest next, affecting streamers today: none of the remaining ten are
+Sharpest next, affecting streamers today: none of the remaining nine are
 flagged as urgent on their own — [#165](https://github.com/clarkio/wos-plus/issues/165)
 and [#167](https://github.com/clarkio/wos-plus/issues/167) overlap open PRs
-(see below), and [#164](https://github.com/clarkio/wos-plus/issues/164) (leading
-`#` stripped on the stats path) is the smallest, cleanest remaining pick with no
-overlap and no architecture question.
+(see below), and [#172](https://github.com/clarkio/wos-plus/issues/172) (export
+the `OPTIONS` handlers the three Supabase-backed routes already advertise) is
+the smallest, cleanest remaining pick with no overlap and no architecture
+question — the pattern to copy (`/api/words`) is already in the tree.
 
 **Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165) overlaps open PR #142, and [#167](https://github.com/clarkio/wos-plus/issues/167) overlaps open PR #144. For #144 especially — recording a slot as solved *without* also blocking the board save would put an unknown word into the archive, the exact failure #167 rules out.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -135,7 +135,6 @@ behaviour, so implementing one forces its test to be inverted deliberately.
 | --- | --- | --- |
 | B1, B2 | The board **save** path must apply the same name, slot and completeness guards as lookup and repair. Today it applies only the repeated-word rule. | [#162](https://github.com/clarkio/wos-plus/issues/162) |
 | B3 | A board is filed under the **longest** word on it, alphabetically last among ties — not the last slot's word. | [#165](https://github.com/clarkio/wos-plus/issues/165) |
-| C1 | A leading `#` is **always** stripped, on the stats path as well as the board path. | [#164](https://github.com/clarkio/wos-plus/issues/164) |
 | G2 | An unrecoverable masked guess **counts as a clear**, but **blocks the board save**. Two outcomes, deliberately decoupled. | [#167](https://github.com/clarkio/wos-plus/issues/167) |
 | G3 | The 12-letter chat filter is correct and stays; the **board name rule comes down** from 20 to 12 to match it. Longest word in the shared list is 8, so 12 is the cushion. | [#168](https://github.com/clarkio/wos-plus/issues/168) |
 | *new* | A board's words must all be spellable from its big word's letters; one that is not makes the board **broken and repairable**. | [#163](https://github.com/clarkio/wos-plus/issues/163) |
@@ -156,6 +155,7 @@ recorded in the spec so these are not raised again.
 | W3 | Missed words stay matched to the archived board **by slot position**. The repair path is what handles a stored board that disagrees with the game, rather than working around it at read time. |
 | ~~C2~~ | ~~The daily badges follow the chatbot **grant**. A failed read must not hide them — it has discovered nothing, not that the channel lost the chatbot.~~ **Fixed** — `GameSpectator.refreshChannelStats()` now only ever turns `chatbotEnabled` on, mirroring the three numbers; the route's own per-request fail-closed answer is unchanged and still correct. Per [#170](https://github.com/clarkio/wos-plus/issues/170). |
 | ~~C3~~ | ~~The record level the game reports **on connect** wins over the stored value, and the stored record is updated.~~ **Fixed, scope narrowed** — display-only in `GameSpectator`'s Game Connected handler; WoS+ never writes the record back itself. The chatbot already keeps the stored value in sync for channels that have it, and nothing has ever written it for channels that don't, so there was no write-back left to build — a client-writable stats endpoint would also have been an unauthenticated write path. Per [#166](https://github.com/clarkio/wos-plus/issues/166). |
+| ~~C1~~ | ~~A leading `#` is **always** stripped, on the stats path as well as the board path.~~ **Fixed** — the route strips a leading `#` before validating, matching `normalizeTwitchChannel` on the board path. Per [#164](https://github.com/clarkio/wos-plus/issues/164). |
 
 Two answers cross-check each other and are worth reading together: **C3** (the
 game wins on connect) and **G5** (the chatbot wins during play). The maintainer

--- a/specs/channel-stats.md
+++ b/specs/channel-stats.md
@@ -204,18 +204,21 @@ case it is typed in.
 
 ---
 
-## Approved, not yet implemented
+## Naming a channel written the way a streamer would type it
 
-### Scenario: a channel name written the way a streamer would type it
+### Scenario: a channel name with a leading hash
 
 - **Given** stats are requested for `#clarkio`
 - **When** WoS+ handles the request
 - **Then** the leading `#` is stripped and the stats for `clarkio` come back
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today *rejects* this as an invalid
-> channel name, while the board path accepts the same input and strips the `#`.
-> The leading `#` should always be stripped, in either case. Tracked by
-> [#164](https://github.com/clarkio/wos-plus/issues/164).
+> ✅ **Confirmed (maintainer)**, fixed by
+> [#164](https://github.com/clarkio/wos-plus/issues/164). The route strips a
+> leading `#` before validating the channel name, the same way
+> `normalizeTwitchChannel` does for the board path, so `#clarkio` and
+> `clarkio` are the same channel everywhere in WoS+.
+
+## Approved, not yet implemented
 
 ### Scenario: the all-time best the game itself reports
 

--- a/src/pages/api/channel-stats/[channel].ts
+++ b/src/pages/api/channel-stats/[channel].ts
@@ -20,7 +20,10 @@ export const GET: APIRoute = async ({ params }) => {
     });
   }
 
-  const cleanChannel = channel.toLowerCase().trim();
+  // Streamers write channel names both with and without a leading '#'; strip
+  // it here the same way normalizeTwitchChannel does for the board path, so
+  // '#clarkio' and 'clarkio' resolve to the same channel everywhere (#164).
+  const cleanChannel = channel.trim().replace(/^#/, '').toLowerCase();
 
   if (!/^[a-z0-9_]+$/.test(cleanChannel)) {
     return new Response(JSON.stringify({ error: 'Invalid channel name format. Only lowercase letters, numbers, and underscores are allowed.' }), {

--- a/tests/acceptance/channel-stats.acceptance.test.ts
+++ b/tests/acceptance/channel-stats.acceptance.test.ts
@@ -783,38 +783,35 @@ describe('specs/channel-stats.md — approved changes, some still not implemente
    */
 
   describe('Scenario: a channel name written the way a streamer would type it', () => {
-    // APPROVED (#164): the leading `#` is stripped and the stats for `clarkio`
-    //                  come back. The maintainer's ruling is that `#` is always
-    //                  stripped, on this path as well as the board path.
-    // TODAY:           it is rejected as an invalid channel name.
-    //
-    // The assertion below pins TODAY. Invert it when #164 lands.
+    // RESOLVED (#164): the leading `#` is stripped and the stats for `clarkio`
+    //                  come back, matching the board path's normaliser.
 
-    it('known gap (#164): rejects a leading hash the board path would accept', async () => {
+    it('#164: strips a leading hash the same way the board path does', async () => {
+      archiveHas({ allTime: allTimeRow(42) });
+
       const response = await invokeRoute(GET, {
         url: '/api/channel-stats/%23clarkio',
         params: { channel: '#clarkio' },
       });
 
-      expect(response.status).toBe(400);
-      expect(await readJson<{ error: string }>(response)).toMatchObject({
-        error: 'Invalid channel name format. Only lowercase letters, numbers, and underscores are allowed.',
+      expect(response.status).toBe(200);
+      expect(await readJson(response)).toMatchObject({
+        allTimePersonalBest: 42,
+        dailyBest: 0,
+        dailyClears: 0,
+        chatbotEnabled: false,
       });
       expect(unhandledNetworkRequests()).toEqual([]);
     });
 
-    it('is the opposite of what the same name gets when a board is recorded', () => {
+    it('now agrees with what the same name gets when a board is recorded', () => {
       /**
-       * The concrete shape of the open question: two normalisers, two answers
-       * for one name a streamer plausibly types either way.
+       * The concrete shape of the fix: one normaliser, one answer for a name a
+       * streamer plausibly types either way.
        *
-       *   - reading stats     → the inline regex in `[channel].ts` rejects it
+       *   - reading stats     → the route strips the leading `#` before validating
        *   - recording a board → `normalizeTwitchChannel` strips the `#` and
        *                         accepts it (see `specs/boards.md`)
-       *
-       * Asserted side by side so the divergence is a fact on the record rather
-       * than a claim in a comment. If the maintainer unifies the two, this test
-       * fails and both halves of the question get answered at once.
        */
       expect(normalizeTwitchChannel('#clarkio')).toBe('clarkio');
       expect(normalizeTwitchChannel('#ClarkIO')).toBe('clarkio');


### PR DESCRIPTION
## What changed

`GET /api/channel-stats/[channel]` rejected a leading `#` (e.g. `#clarkio`) as an invalid channel name, while the board-save path's `normalizeTwitchChannel` already strips it and accepts the same input. Streamers write channel names both ways, so this closes the gap tracked by [#164](https://github.com/clarkio/wos-plus/issues/164) — the leading `#` is now stripped before validation, matching the board path.

This is the next step from `AGENTIC-TESTING-PLAN.md § Where this stands`, which flagged #164 as the smallest, cleanest remaining item in the behaviour backlog from the #160 review (C1). `specs/channel-stats.md`, `specs/README.md`, and the plan's status section are updated accordingly.

## Verification

- [x] Spec in `specs/` added or updated — `specs/channel-stats.md` scenario moved from ⚠️ **Approved, not yet implemented** to ✅ **Confirmed (maintainer)**; `specs/README.md` decision table (C1) updated
- [x] Tests written or updated *before or with* the implementation — the existing `known gap (#164)` acceptance canary in `channel-stats.acceptance.test.ts` was inverted (not deleted), per `CLAUDE.md` §2.3
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally — 645 passing tests (+0 net, canary inverted in place), coverage unchanged at 90.94%/86.7%/87.86%/91.66%, all above thresholds
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

No architectural change — this only touches the validation/normalisation step in one route handler, plus the accompanying spec/test/plan bookkeeping. `AGENTIC-TESTING-PLAN.md`'s "Sharpest next" pointer is updated to the next candidate ([#172](https://github.com/clarkio/wos-plus/issues/172), exporting the `OPTIONS` handlers the Supabase-backed routes already advertise).

---
_Generated by [Claude Code](https://claude.ai/code/session_018hEHkw77y1yTXYBm93eVFL)_