### PR TITLE
Apply the same name, slot-shape and completeness guards to board save (#162)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -30,10 +30,10 @@ describe intent, not status. This section is the status.
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
 
-### The numbers, as of the #171 fix
+### The numbers, as of the #162 fix
 
-**658 passing** tests across 19 files, plus 5 deliberate `it.todo`. Coverage
-**90.98% statements / 86.88% branches / 88.13% functions / 91.68% lines**, counting
+**673 passing** tests across 19 files, plus 4 deliberate `it.todo`. Coverage
+**91.05% statements / 87.17% branches / 88.2% functions / 91.75% lines**, counting
 every file under `src/**/*.ts` so an untested module shows as 0% rather than being
 invisible. `src/scripts/wos-widget.ts` is the one module no test imports.
 
@@ -66,11 +66,30 @@ Thirteen issues, all approved by the maintainer:
 [#164](https://github.com/clarkio/wos-plus/issues/164),
 [#168](https://github.com/clarkio/wos-plus/issues/168),
 [#161](https://github.com/clarkio/wos-plus/issues/161),
-[#163](https://github.com/clarkio/wos-plus/issues/163) and
-[#171](https://github.com/clarkio/wos-plus/issues/171) are done** (PR
+[#163](https://github.com/clarkio/wos-plus/issues/163),
+[#171](https://github.com/clarkio/wos-plus/issues/171) and
+[#162](https://github.com/clarkio/wos-plus/issues/162) are done** (PR
 [#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix, the
-#166 fix, the #164 fix, the #168 fix, the #161 fix, the #163 fix and the
-#171 fix) — five remain.
+#166 fix, the #164 fix, the #168 fix, the #161 fix, the #163 fix, the
+#171 fix and the #162 fix) — four remain.
+
+**#162 is done** — `POST /api/boards` now applies the same board-name and
+slot-shape rules that lookup (`GET /api/boards/[id]`) and repair (`PUT
+/api/boards/[id]`) already enforced. Two helpers moved to
+`src/lib/board-utils.ts` so all three routes share one implementation instead
+of three: `validateBoardName` (the 4–12-letters-only rule, previously private
+to `[id].ts`) and `isWellFormedSlot` (the `letters` array + non-empty `word`
+shape check, previously inlined in the `PUT` handler). A save whose id isn't
+present is still let through to the guard that actually explains it (redundant
+words, then language) rather than being blocked by a name check that was never
+the point of those scenarios — matching the existing acceptance tests that
+capture a nameless board on purpose. The slot-shape guard also closes the
+completeness gap noted under "Capturing a board": a slot with an empty word is
+exactly what it rejects, so the `it.todo` there became a real test. The two
+`known gap (#162)` describes in `boards.acceptance.test.ts` were moved into a
+new `specs/boards.md — Saving a board directly` describe and inverted, not
+deleted; `specs/boards.md` § Saving a board directly is now ✅ Confirmed for
+both scenarios.
 
 **#171 is done** — the retired client-side word-adding path is gone, not just
 unreachable: `updateWordsDb` in `src/scripts/wos-words.ts` (PATCHed the
@@ -168,14 +187,27 @@ covers two independent reasons a board can be broken.
 `specs/boards.md` § Repairing a board that was stored badly is now ✅
 Confirmed rather than ⚠️ for that scenario.
 
-Sharpest next, affecting streamers today: none of the remaining five are
+Sharpest next, affecting streamers today: none of the remaining four are
 flagged as urgent on their own — [#165](https://github.com/clarkio/wos-plus/issues/165)
 and [#167](https://github.com/clarkio/wos-plus/issues/167) overlap open PRs
-(see below). With #172, #168, #161, #163 and #171 done, the next cleanest pick
-without an overlapping PR is [#162](https://github.com/clarkio/wos-plus/issues/162)
-— it is also the largest of what remains, since it adds real validation logic
-to the board save path rather than deleting dead code or narrowing a display
-bug, so budget more room for it than the last few.
+(see below). With #172, #168, #161, #163, #171 and #162 done, the next
+cleanest pick without an overlapping PR is
+[#164](https://github.com/clarkio/wos-plus/issues/164) — small.
+[#169](https://github.com/clarkio/wos-plus/issues/169) (rebuild the found-words
+list on reconnect) is the other option without an overlapping PR, and the
+larger of the two — it touches `GameSpectator`'s reconnect handling in
+`wos-plus-main.ts`, not just a route.
+
+Note: GitHub still shows issue #164 open, but its *behaviour* (strip a leading
+`#` from the channel name on the channel-stats read path) already exists in
+`src/pages/api/channel-stats/[channel].ts`, inline with a comment citing
+#164 — it just reimplements the same regex `normalizeTwitchChannel`
+(`src/lib/board-utils.ts`) already applies to the board path, rather than
+reusing it. That duplication is exactly the kind #133 tracks separately. So
+#164's actual remaining work is small: replace the inline regex with
+`normalizeTwitchChannel`, verify the acceptance test still pins the same
+behaviour, and close the tracking issue — not implement the strip from
+scratch.
 
 **Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165) overlaps open PR #142, and [#167](https://github.com/clarkio/wos-plus/issues/167) overlaps open PR #144. For #144 especially — recording a slot as solved *without* also blocking the board save would put an unknown word into the archive, the exact failure #167 rules out.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Prefer a failing build over a paragraph of good advice.
 
 ## 4. Known state (keep current)
 
-- Test suite: **658 passing** Vitest tests across 19 files, plus **5
+- Test suite: **673 passing** Vitest tests across 19 files, plus **4
   `it.todo`**. Every remaining todo is a **known gap with a tracking issue or a
   stated coverage limitation** — none is simply an unwritten test, and none may
   be deleted to tidy the count. The decisions behind them are tabulated in
@@ -150,8 +150,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **90.98% statements / 86.88% branches / 88.13% functions /
-  91.68% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **91.05% statements / 87.17% branches / 88.2% functions /
+  91.75% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/specs/boards.md
+++ b/specs/boards.md
@@ -142,6 +142,12 @@ A board is only ever captured from a level WoS+ believes is complete — see
 - **When** WoS+ tries to save it
 - **Then** nothing is saved — an incomplete board is worse than no board
 
+> ✅ **Confirmed (maintainer)** — enforced at two layers. The capture side in
+> `src/scripts/wos-plus-main.ts` only offers a board once every slot is
+> solved; since [#162](https://github.com/clarkio/wos-plus/issues/162), `POST
+> /api/boards` also refuses a slot with an empty word directly, so the archive
+> no longer relies on caller discipline alone.
+
 ---
 
 ## Channel and language on a captured board
@@ -352,10 +358,12 @@ must hold to the same rules as every other.
 - **When** the save is attempted
 - **Then** the board is rejected as an invalid board name, and nothing is saved
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today does not check the name on
-> save, so such a board reaches the archive and is then unreachable: the lookup
-> rules that would find it reject the very name it was stored under. Tracked by
-> [#162](https://github.com/clarkio/wos-plus/issues/162).
+> ✅ **Confirmed (maintainer)** — implemented in
+> [#162](https://github.com/clarkio/wos-plus/issues/162). `POST /api/boards`
+> now validates the board id with the same `validateBoardName` rule that
+> `[id].ts` already applied on lookup and repair (`src/lib/board-utils.ts`),
+> so a board can no longer be filed under a name the lookup path will then
+> always reject.
 
 ### Scenario: a board offered for saving with malformed slots
 
@@ -364,10 +372,12 @@ must hold to the same rules as every other.
 - **When** the save is attempted
 - **Then** the board is rejected, and nothing is saved
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today applies only the
-> repeated-word rule here, so a *repair* of the same board is rejected while the
-> *save* succeeds. Tracked by
-> [#162](https://github.com/clarkio/wos-plus/issues/162).
+> ✅ **Confirmed (maintainer)** — implemented in
+> [#162](https://github.com/clarkio/wos-plus/issues/162). `POST /api/boards`
+> now rejects a missing or malformed `slots` array with the same
+> `isWellFormedSlot` check `PUT /api/boards/[id]` already applied on repair.
+> This also closes the completeness gap noted under "Capturing a board" above:
+> an unsolved slot (empty word) is exactly the shape this guard rejects.
 
 ### Scenario: which word a board is filed under
 

--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -98,6 +98,48 @@ export function hasInvalidWords(slots: unknown, bigWord: string): boolean {
   return findInvalidWords(slots, bigWord).length > 0;
 }
 
+/**
+ * True when a single slot has the shape a board write needs: an object with
+ * a `letters` array and a non-empty `word` string. Shared by the repair path
+ * (PUT /api/boards/[id]) and the save path (POST /api/boards, issue #162) so
+ * the two write paths cannot disagree about what a valid slot is.
+ */
+export function isWellFormedSlot(slot: unknown): boolean {
+  return (
+    !!slot &&
+    typeof slot === 'object' &&
+    Array.isArray((slot as { letters?: unknown }).letters) &&
+    typeof (slot as { word?: unknown }).word === 'string' &&
+    (slot as { word: string }).word.length > 0
+  );
+}
+
+/**
+ * Validates and normalizes a board id against the same rules
+ * specs/boards.md § Naming a board enforces on lookup (`validateBoardId` in
+ * `[id].ts`): letters only, 4-12 characters once whitespace is stripped and
+ * the value is upper-cased. Shared with the save path (POST /api/boards,
+ * issue #162) so a board can no longer be filed under a name the lookup path
+ * will then always reject.
+ */
+export function validateBoardName(id: unknown): { cleanId: string } | { error: string } {
+  if (typeof id !== 'string' || id.length === 0) {
+    return { error: 'Board ID is required' };
+  }
+
+  const cleanId = id.replace(/\s+/g, '').toUpperCase();
+
+  if (!/^[A-Z]+$/.test(cleanId)) {
+    return { error: 'Invalid board ID format. Only letters are allowed.' };
+  }
+
+  if (cleanId.length < 4 || cleanId.length > 12) {
+    return { error: 'Invalid board ID length. Must be between 4 and 12 characters.' };
+  }
+
+  return { cleanId };
+}
+
 // Words on Stream supports three word languages. The game's socket events
 // carry the language as a numeric id (e.g. on the "Game Connected" payload);
 // the official wos.gg client resolves that id through its /api/language?id=N

--- a/src/pages/api/boards/[id].ts
+++ b/src/pages/api/boards/[id].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords, hasInvalidWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../../../lib/board-utils';
+import { findRedundantWords, hasInvalidWords, hasRedundantWords, isWellFormedSlot, normalizeLanguageCode, normalizeTwitchChannel, validateBoardName } from '../../../lib/board-utils';
 
 export const prerender = false;
 
@@ -20,25 +20,15 @@ const jsonResponse = (body: object, status = 200) =>
 // Security validation: sanitize and validate board ID.
 // Board IDs should only contain letters (they are words from the game).
 // Returns the cleaned ID, or an error response when validation fails.
+// The rules themselves live in `validateBoardName` (src/lib/board-utils.ts),
+// shared with the POST save path (issue #162); this just shapes the result
+// into the Response this route's callers expect.
 function validateBoardId(id: string | undefined): { cleanId: string } | { errorResponse: Response } {
-  if (!id) {
-    return { errorResponse: jsonResponse({ error: 'Board ID is required' }, 400) };
+  const result = validateBoardName(id);
+  if ('error' in result) {
+    return { errorResponse: jsonResponse({ error: result.error }, 400) };
   }
-
-  const cleanId = id.replace(/\s+/g, '').toUpperCase();
-
-  // Validate: only alphabetic characters allowed
-  if (!/^[A-Z]+$/.test(cleanId)) {
-    return { errorResponse: jsonResponse({ error: 'Invalid board ID format. Only letters are allowed.' }, 400) };
-  }
-
-  // Validate: reasonable length (game words are typically 4-12 characters;
-  // see specs/boards.md § Naming a board for why 12 is the cushion, issue #168)
-  if (cleanId.length < 4 || cleanId.length > 12) {
-    return { errorResponse: jsonResponse({ error: 'Invalid board ID length. Must be between 4 and 12 characters.' }, 400) };
-  }
-
-  return { cleanId };
+  return result;
 }
 
 // Handle CORS preflight requests (issue #172).
@@ -112,14 +102,7 @@ export const PUT: APIRoute = async ({ params, request }) => {
     return jsonResponse({ error: 'slots must be a non-empty array' }, 400);
   }
 
-  const isValidSlots = slots.every(slot =>
-    slot &&
-    typeof slot === 'object' &&
-    Array.isArray(slot.letters) &&
-    typeof slot.word === 'string' &&
-    slot.word.length > 0
-  );
-  if (!isValidSlots) {
+  if (!slots.every(isWellFormedSlot)) {
     return jsonResponse({ error: 'Invalid slot structure detected' }, 400);
   }
 

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
-import { findRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../../../lib/board-utils';
+import { findRedundantWords, isWellFormedSlot, normalizeLanguageCode, normalizeTwitchChannel, validateBoardName } from '../../../lib/board-utils';
 
 export const prerender = false;
 const corsHeaders = {
@@ -53,6 +53,28 @@ export const POST: APIRoute = async ({ request }) => {
     });
   }
 
+  // Guard (issue #162): the save path must apply the same board-name rule
+  // lookup and repair already enforce (specs/boards.md § Naming a board).
+  // Only checked when a name was actually offered — a completely nameless
+  // capture is a different failure (the archive's own not-null constraint,
+  // or another guard below), not a bad name.
+  if (body?.id !== undefined) {
+    const nameValidation = validateBoardName(body.id);
+    if ('error' in nameValidation) {
+      return new Response(
+        JSON.stringify({
+          error: nameValidation.error,
+          message: `Board ${body.id} was not saved: ${nameValidation.error}.`,
+          code: 'INVALID_BOARD_ID',
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+  }
+
   // Guard (issue #119): reject boards whose slots contain the same word more
   // than once — that data is corrupted and would need manual cleanup later.
   const redundantWords = findRedundantWords(body?.slots);
@@ -101,6 +123,25 @@ export const POST: APIRoute = async ({ request }) => {
     );
   }
   body.language_code = cleanLanguageCode;
+
+  // Guard (issue #162): the save path must apply the same slot-shape rule the
+  // repair path already enforces (PUT /api/boards/[id]) — every slot needs a
+  // `letters` array and a non-empty `word`. This is also what keeps an
+  // incomplete capture (a slot whose word was never fully worked out) out of
+  // the archive, since an unsolved slot is exactly a slot with no word.
+  if (!Array.isArray(body?.slots) || body.slots.length === 0 || !body.slots.every(isWellFormedSlot)) {
+    return new Response(
+      JSON.stringify({
+        error: 'Invalid slot structure detected',
+        message: `Board ${body?.id || 'ID'} was not saved: its slots are missing letters or a word.`,
+        code: 'INVALID_SLOTS',
+      }),
+      {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  }
 
   try {
     const supabase = createClient(

--- a/tests/acceptance/boards.acceptance.test.ts
+++ b/tests/acceptance/boards.acceptance.test.ts
@@ -18,11 +18,12 @@
  * - `src/pages/api/boards/[id].ts` — `GET` looks one board up; `PUT` repairs a
  *   stored board that was saved with the same word in two slots (issue #119).
  *
- * The board **name** rules in `specs/boards.md § Naming a board` are enforced
- * by `validateBoardId` in `[id].ts` — that is, on *lookup* and *repair*, but
- * **not** on the `POST` save path. The spec records that asymmetry as an open
- * question, and the tests below treat it as one rather than as contract. See
- * the "Open questions" describe at the foot of this file.
+ * The board **name** and **slot-shape** rules in `specs/boards.md § Naming a
+ * board` and `§ Saving a board directly` are shared, via `validateBoardName`
+ * and `isWellFormedSlot` in `src/lib/board-utils.ts`, across *lookup*,
+ * *repair* and the `POST` save path (issue #162) — the save path used to skip
+ * both, which let a board be filed under a name lookup would then always
+ * reject.
  *
  * ---------------------------------------------------------------------------
  * How these tests prove a route did *not* touch the archive
@@ -1312,22 +1313,26 @@ describe('specs/boards.md — Capturing a board', () => {
     // When WoS+ tries to save it
     // Then nothing is saved — an incomplete board is worse than no board
     //
-    // This scenario is NOT enforced by this route. The route's only slot check
-    // is the repeated-word guard; a slot with an empty word is simply ignored
-    // by `findRedundantWords` and the board is saved as-is. The spec records
-    // that gap under "Open questions" as "a board saved with malformed slots",
-    // and it is pinned there rather than asserted as contract here.
-    //
-    // What *does* enforce it today is the capture side in
-    // `src/scripts/wos-plus-main.ts`, which only offers a board once every slot
-    // is solved. That is out of this task's scope (game flow is task 6), so
-    // this describe deliberately asserts nothing and points at both halves.
+    // The capture side in `src/scripts/wos-plus-main.ts` only offers a board
+    // once every slot is solved, but that is caller discipline, not a
+    // guarantee — see specs/boards.md § Saving a board directly. Since #162,
+    // this route also refuses an unsolved slot directly: a slot with an empty
+    // word is exactly the shape `isWellFormedSlot` rejects.
 
-    it.todo(
-      'incomplete captures are refused by the archive itself — ' +
-      'open question: the route does not check slot completeness, only repeated words; ' +
-      'see the "a board saved with malformed slots" open question below',
-    );
+    it('rejects the capture and saves nothing when a slot still has an empty word', async () => {
+      const response = await invokeRoute(POST, {
+        method: 'POST',
+        url: '/api/boards',
+        json: {
+          id: 'CAUTION',
+          slots: [slot('ACT'), { letters: Array.from('COAT'), word: '' }, slot('CAUTION')],
+          language_code: 'en',
+        },
+      });
+
+      expect(response.status).toBe(400);
+      expect(unhandledNetworkRequests()).toEqual([]);
+    });
   });
 });
 
@@ -1822,91 +1827,51 @@ describe('/api/boards — transport concerns (no spec section)', () => {
 });
 
 // ===========================================================================
-// specs/boards.md § Saving a board directly, § Known limitations
+// specs/boards.md § Saving a board directly
 //
-// ANSWERED by the maintainer in review of PR #160. These were open questions;
-// they are now decisions, and the spec has been rewritten to state the approved
-// behaviour rather than the current behaviour.
+// #162 landed: the save path now applies the same board-name and slot-shape
+// rules the lookup and repair paths already enforced. These describes used to
+// live in the "approved changes not yet implemented" block below, pinning
+// today's (wrong) behaviour under protest; they are inverted here, not
+// deleted, per CLAUDE.md §2.2.
 // ===========================================================================
 
-describe('specs/boards.md — approved changes not yet implemented (current behaviour under protest)', () => {
-  /**
-   * Every test in this block asserts what WoS+ does **today**, which the
-   * maintainer has now ruled is **wrong**. They are kept, not deleted, and this
-   * is deliberate — per `CLAUDE.md` §2.2 an existing assertion is never removed
-   * to make a change pass.
-   *
-   * Their job has changed. They no longer ask a question; they hold the current
-   * behaviour still so that implementing the approved change cannot happen
-   * silently. Landing #162 or #165 *must* turn these red, and the fix is to
-   * invert each assertion in that same PR — not to delete it here first.
-   *
-   * If you are reading this because one of them just failed: that is the
-   * mechanism working. Check the issue named on the test, and invert it.
-   */
-
+describe('specs/boards.md — Saving a board directly', () => {
   describe('Scenario: a board offered for saving under a name that is not a big word', () => {
-    // APPROVED (#162): the board is rejected as an invalid board name, and
-    //                  nothing is saved.
-    // TODAY:           the name is not checked, and the board is saved.
-    //
-    // The assertions below pin TODAY. Invert them when #162 lands.
+    // Given a board is offered for saving with a name that is not 4-12
+    //       letters — for example `CAT` or `CAUT10N`
+    // When the save is attempted
+    // Then the board is rejected as an invalid board name, and nothing is
+    //      saved
 
     it.each([
       ['a name that is too short', 'CAT'],
       ['a name with a digit in it', 'CAUT10N'],
       ['a name that is too long', 'A'.repeat(21)],
       ['a name that is not letters at all', '!!!'],
-    ])('known gap (#162): stores a board named with %s', async (_label, id) => {
-      /**
-       * KNOWN GAP (#162) — pins current behaviour; the maintainer has ruled it wrong.
-       *
-       * Approved: the save path applies the same name rules as the
-       * lookup and repair paths? `validateBoardId` lives in `[id].ts` and is
-       * never called by `index.ts`, so a board can be filed under a name that
-       * the lookup rules will then always reject — see the companion test
-       * below, which shows the board becoming unreachable.
-       *
-       * Asserted only to make the asymmetry visible and to fail loudly if it
-       * changes. NOT a statement that saving such a board is right.
-       */
-      const insert = requestRecorder();
-      server.use(supabaseSuccess('boards', [storedBoard({ id })], {
-        method: 'post',
-        once: true,
-        onRequest: insert.onRequest,
-      }));
-
+    ])('#162 landed: rejects a board named with %s, and saves nothing', async (_label, id) => {
       const response = await invokeRoute(POST, {
         method: 'POST',
         url: '/api/boards',
         json: { id, slots: CLEAN_SLOTS, language_code: 'en' },
       });
 
-      expect(response.status).toBe(200);
-      expect(insert.captured.body).toMatchObject({ id });
+      expect(response.status).toBe(400);
+      expect(await readJson<{ code: string }>(response)).toMatchObject({ code: 'INVALID_BOARD_ID' });
+      expect(unhandledNetworkRequests()).toEqual([]);
     });
 
-    it('known gap (#162): a board saved under a bad name can then never be looked up', async () => {
-      /**
-       * KNOWN GAP (#162) — the consequence of the asymmetry above, spelled out.
-       *
-       * The save succeeds; the lookup of the very same name is rejected before
-       * the archive is consulted. The board is in the archive and unreachable
-       * through the normal path. The maintainer has ruled the save path must
-       * apply the same name rules, so this test inverts when #162 lands.
-       */
-      server.use(supabaseSuccess('boards', [storedBoard({ id: 'CAUT10N' })], {
-        method: 'post',
-        once: true,
-      }));
-
+    it('#162 landed: a board rejected on save is never left unreachable at lookup', async () => {
+      // The old failure mode this replaces: a save that skipped the name
+      // check would succeed, then the very same name would 400 on lookup —
+      // a board in the archive that the normal path could never reach again.
       const saved = await invokeRoute(POST, {
         method: 'POST',
         url: '/api/boards',
         json: { id: 'CAUT10N', slots: CLEAN_SLOTS, language_code: 'en' },
       });
-      expect(saved.status).toBe(200);
+      expect(saved.status).toBe(400);
+      expect(unhandledNetworkRequests()).toEqual([]);
 
       const lookup = await invokeRoute(GET_BOARD, {
         url: '/api/boards/CAUT10N',
@@ -1924,8 +1889,7 @@ describe('specs/boards.md — approved changes not yet implemented (current beha
     // Given a board is offered for saving whose slots have no letters, or no
     //       words
     // When the save is attempted
-    // Then only the repeated-word rule is applied; the slots' shape is not
-    //      checked, and the board is saved
+    // Then the board is rejected, and nothing is saved
 
     it.each([
       ['a slot with no letters', [{ word: 'ACTION' }, slot('CAUTION')]],
@@ -1933,37 +1897,57 @@ describe('specs/boards.md — approved changes not yet implemented (current beha
       ['a slot with an empty word', [{ letters: Array.from('ACTION'), word: '' }, slot('CAUTION')]],
       ['a slot that is null', [null, slot('CAUTION')]],
       ['no slots at all', []],
-    ])('known gap (#162): stores a board containing %s', async (_label, slots) => {
-      /**
-       * KNOWN GAP (#162) — pins current behaviour; the maintainer has ruled it wrong.
-       *
-       * Approved: the save path applies the same slot-shape rules as
-       * the repair path? `PUT /api/boards/[id]` rejects every one of these with
-       * `Invalid slot structure detected` (see the "a repair with a malformed
-       * slot" describe above), while `POST` stores them. The two paths disagree
-       * about what a valid slot is.
-       *
-       * This is also what leaves `specs/boards.md § a capture where a word was
-       * never fully worked out` unenforced at the archive: a slot with an empty
-       * word is exactly an unsolved slot.
-       */
-      const insert = requestRecorder();
-      server.use(supabaseSuccess('boards', [storedBoard()], {
-        method: 'post',
-        once: true,
-        onRequest: insert.onRequest,
-      }));
-
+    ])('#162 landed: rejects a board containing %s, and saves nothing', async (_label, slots) => {
       const response = await invokeRoute(POST, {
         method: 'POST',
         url: '/api/boards',
         json: { id: 'CAUTION', slots, language_code: 'en' },
       });
 
-      expect(response.status).toBe(200);
-      expect(insert.captured.body).toMatchObject({ slots });
+      expect(response.status).toBe(400);
+      expect(await readJson<{ code: string }>(response)).toMatchObject({ code: 'INVALID_SLOTS' });
+      expect(unhandledNetworkRequests()).toEqual([]);
+    });
+
+    it('#162 landed: names the board as "ID" when the capture carried no id either', async () => {
+      const response = await invokeRoute(POST, {
+        method: 'POST',
+        url: '/api/boards',
+        json: { slots: [], language_code: 'en' },
+      });
+
+      expect(response.status).toBe(400);
+      expect(await readJson<{ message: string }>(response)).toMatchObject({
+        message: 'Board ID was not saved: its slots are missing letters or a word.',
+      });
+      expect(unhandledNetworkRequests()).toEqual([]);
     });
   });
+});
+
+// ===========================================================================
+// specs/boards.md § Saving a board directly (remaining gap), § Known limitations
+//
+// ANSWERED by the maintainer in review of PR #160. These were open questions;
+// they are now decisions, and the spec has been rewritten to state the approved
+// behaviour rather than the current behaviour.
+// ===========================================================================
+
+describe('specs/boards.md — approved changes not yet implemented (current behaviour under protest)', () => {
+  /**
+   * Every test in this block asserts what WoS+ does **today**, which the
+   * maintainer has now ruled is **wrong**. They are kept, not deleted, and this
+   * is deliberate — per `CLAUDE.md` §2.2 an existing assertion is never removed
+   * to make a change pass.
+   *
+   * Their job has changed. They no longer ask a question; they hold the current
+   * behaviour still so that implementing the approved change cannot happen
+   * silently. Landing #165 *must* turn this red, and the fix is to invert the
+   * assertion in that same PR — not to delete it here first.
+   *
+   * If you are reading this because it just failed: that is the mechanism
+   * working. Check the issue named on the test, and invert it.
+   */
 
   describe('Scenario: the big word disagrees with the last slot', () => {
     // Given a level is being captured

--- a/tests/unit/board-utils.test.ts
+++ b/tests/unit/board-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { coerceSlots, findInvalidWords, findRedundantWords, hasInvalidWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel, wosLanguageIdToCode } from '@/lib/board-utils';
+import { coerceSlots, findInvalidWords, findRedundantWords, hasInvalidWords, hasRedundantWords, isWellFormedSlot, normalizeLanguageCode, normalizeTwitchChannel, validateBoardName, wosLanguageIdToCode } from '@/lib/board-utils';
 
 /**
  * Unit tests for board-utils.ts module (issue #119)
@@ -240,6 +240,72 @@ describe('board-utils module', () => {
       expect(wosLanguageIdToCode(null)).toBeNull();
       expect(wosLanguageIdToCode(undefined)).toBeNull();
       expect(wosLanguageIdToCode({})).toBeNull();
+    });
+  });
+
+  describe('isWellFormedSlot (issue #162)', () => {
+    it('should accept a slot with letters and a non-empty word', () => {
+      expect(isWellFormedSlot({ letters: ['A', 'C', 'T'], word: 'ACT' })).toBe(true);
+    });
+
+    it('should reject a slot with no letters', () => {
+      expect(isWellFormedSlot({ word: 'ACT' })).toBe(false);
+    });
+
+    it('should reject a slot whose letters are not a list', () => {
+      expect(isWellFormedSlot({ letters: 'ACT', word: 'ACT' })).toBe(false);
+    });
+
+    it('should reject a slot with no word', () => {
+      expect(isWellFormedSlot({ letters: ['A', 'C', 'T'] })).toBe(false);
+    });
+
+    it('should reject a slot with an empty word', () => {
+      expect(isWellFormedSlot({ letters: ['A', 'C', 'T'], word: '' })).toBe(false);
+    });
+
+    it('should reject a slot whose word is not text', () => {
+      expect(isWellFormedSlot({ letters: ['A', 'C', 'T'], word: 42 })).toBe(false);
+    });
+
+    it('should reject null and non-object slots', () => {
+      expect(isWellFormedSlot(null)).toBe(false);
+      expect(isWellFormedSlot(undefined)).toBe(false);
+      expect(isWellFormedSlot('ACT')).toBe(false);
+    });
+  });
+
+  describe('validateBoardName (issue #162)', () => {
+    it('should accept a 4-12 letter name', () => {
+      expect(validateBoardName('CAUTION')).toEqual({ cleanId: 'CAUTION' });
+    });
+
+    it('should upper-case and strip whitespace from a valid name', () => {
+      expect(validateBoardName(' c a u t i o n ')).toEqual({ cleanId: 'CAUTION' });
+    });
+
+    it('should reject a name shorter than 4 letters', () => {
+      expect(validateBoardName('CAT')).toEqual({
+        error: 'Invalid board ID length. Must be between 4 and 12 characters.',
+      });
+    });
+
+    it('should reject a name longer than 12 letters', () => {
+      expect(validateBoardName('A'.repeat(13))).toEqual({
+        error: 'Invalid board ID length. Must be between 4 and 12 characters.',
+      });
+    });
+
+    it('should reject a name containing anything other than letters', () => {
+      expect(validateBoardName('CAUT10N')).toEqual({
+        error: 'Invalid board ID format. Only letters are allowed.',
+      });
+    });
+
+    it('should reject a missing or non-string name', () => {
+      expect(validateBoardName(undefined)).toEqual({ error: 'Board ID is required' });
+      expect(validateBoardName('')).toEqual({ error: 'Board ID is required' });
+      expect(validateBoardName(42)).toEqual({ error: 'Board ID is required' });
     });
   });
 


### PR DESCRIPTION
## What changed

Resolves #162 — the next item on the [AGENTIC-TESTING-PLAN.md behaviour backlog](AGENTIC-TESTING-PLAN.md#the-behaviour-backlog-from-the-160-review).

`POST /api/boards` used to apply only the repeated-word rule, so a board could be saved under a name (`CAT`, `CAUT10N`) the lookup path (`GET /api/boards/[id]`) would then always reject, or with malformed/empty slots that the repair path (`PUT /api/boards/[id]`) already refused. Now all three routes apply the same rules:

- **`validateBoardName`** (new, `src/lib/board-utils.ts`) — the 4–12-letters-only board-id rule, previously private to `[id].ts`. `[id].ts` now delegates to it instead of duplicating the check.
- **`isWellFormedSlot`** (new, `src/lib/board-utils.ts`) — the "has a `letters` array and a non-empty `word`" shape check, previously inlined only in the `PUT` handler. Both `POST` and `PUT` now share it.
- `POST /api/boards` applies both: the name check only when an `id` is actually offered (a nameless capture still fails on the guard that already explained it — redundant words or missing language — matching existing acceptance tests that exercise that case on purpose), and the slot-shape check after the language check so existing "no language" tests are unaffected.
- This also closes the completeness gap noted in `specs/boards.md` § Capturing a board: an unsolved slot (empty word) is exactly the shape `isWellFormedSlot` rejects, so a slot never fully worked out can no longer reach the archive through this route either.

## Verification

- [x] Spec in `specs/` added or updated — `specs/boards.md` § Saving a board directly: both scenarios moved from ⚠️ Approved-not-yet-implemented to ✅ Confirmed; § Capturing a board's completeness scenario got a confirmation note too.
- [x] Tests written or updated *before or with* the implementation — the two `known gap (#162)` acceptance describes were inverted (not deleted, per `CLAUDE.md` §2.2) into a new `specs/boards.md — Saving a board directly` describe; the completeness `it.todo` became a real test; new unit tests added for `validateBoardName` and `isWellFormedSlot`.
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally:
  - `check`: 0 errors, 0 warnings (15 pre-existing hints)
  - `lint`: clean, `--max-warnings 0`
  - `test:coverage`: **673 passed, 4 todo** (was 658 passed / 5 todo) across 19 files. Coverage **91.05% / 87.17% / 88.2% / 91.75%** (stmts/branches/funcs/lines) — up from 90.98/86.88/88.13/91.68, still above the enforced floor (90/85/86/90 global).
  - `build`: succeeds
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

- `CLAUDE.md` § 4 and `AGENTIC-TESTING-PLAN.md` § Where this stands were updated with the new counts and #162's completion, per the "keep instructions load-bearing" rule (`CLAUDE.md` §6).
- While updating the plan doc I noticed GitHub still shows **#164** open even though its behaviour (strip a leading `#` from the channel name on the channel-stats read path) already exists in `src/pages/api/channel-stats/[channel].ts` — it just reimplements the regex inline instead of reusing `normalizeTwitchChannel`. Left as a note in the plan for whoever picks up #164 next; out of scope here.
- Remaining behaviour-backlog issues after this one: #164, #165 (overlaps open PR #142), #167 (overlaps open PR #144), #169.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U4JdemnYoAVHNZxErT1het)_