### PR TITLE
Share the leading-# strip between channel-stats and board normalisation (#164)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -71,7 +71,7 @@ Thirteen issues, all approved by the maintainer:
 [#162](https://github.com/clarkio/wos-plus/issues/162) are done** (PR
 [#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix, the
 #166 fix, the #164 fix, the #168 fix, the #161 fix, the #163 fix, the
-#171 fix and the #162 fix) — four remain.
+#171 fix and the #162 fix) — three remain.
 
 **#162 is done** — `POST /api/boards` now applies the same board-name and
 slot-shape rules that lookup (`GET /api/boards/[id]`) and repair (`PUT
@@ -187,27 +187,30 @@ covers two independent reasons a board can be broken.
 `specs/boards.md` § Repairing a board that was stored badly is now ✅
 Confirmed rather than ⚠️ for that scenario.
 
-Sharpest next, affecting streamers today: none of the remaining four are
+**#164 is done** — the leading-`#` strip on the channel-stats read path
+(`src/pages/api/channel-stats/[channel].ts`) already matched the board path's
+behaviour, but reimplemented the transform inline instead of sharing it with
+`normalizeTwitchChannel` (`src/lib/board-utils.ts`). The shared step —
+trim, strip a leading `#`, lowercase — is now `cleanTwitchChannel`, exported
+from `board-utils.ts` and used by both `normalizeTwitchChannel` (board path)
+and the channel-stats route, instead of being duplicated. The route keeps its
+own format/length checks after cleaning (not a call to `normalizeTwitchChannel`
+itself), because the two paths give a caller different error messages for "bad
+characters" vs. "too long" and `normalizeTwitchChannel` collapses both into a
+single null — folding that distinction away for a strings-only refactor would
+have been an unrelated behaviour change. No acceptance test changed; the
+`#164` scenario in `channel-stats.acceptance.test.ts` (§ "a channel name
+written the way a streamer would type it") already pinned the correct
+behaviour and stays green, unchanged.
+
+Sharpest next, affecting streamers today: none of the remaining three are
 flagged as urgent on their own — [#165](https://github.com/clarkio/wos-plus/issues/165)
 and [#167](https://github.com/clarkio/wos-plus/issues/167) overlap open PRs
-(see below). With #172, #168, #161, #163, #171 and #162 done, the next
-cleanest pick without an overlapping PR is
-[#164](https://github.com/clarkio/wos-plus/issues/164) — small.
+(see below). With #172, #168, #161, #163, #171, #162 and #164 done, the
+remaining pick without an overlapping PR is
 [#169](https://github.com/clarkio/wos-plus/issues/169) (rebuild the found-words
-list on reconnect) is the other option without an overlapping PR, and the
-larger of the two — it touches `GameSpectator`'s reconnect handling in
+list on reconnect) — it touches `GameSpectator`'s reconnect handling in
 `wos-plus-main.ts`, not just a route.
-
-Note: GitHub still shows issue #164 open, but its *behaviour* (strip a leading
-`#` from the channel name on the channel-stats read path) already exists in
-`src/pages/api/channel-stats/[channel].ts`, inline with a comment citing
-#164 — it just reimplements the same regex `normalizeTwitchChannel`
-(`src/lib/board-utils.ts`) already applies to the board path, rather than
-reusing it. That duplication is exactly the kind #133 tracks separately. So
-#164's actual remaining work is small: replace the inline regex with
-`normalizeTwitchChannel`, verify the acceptance test still pins the same
-behaviour, and close the tracking issue — not implement the strip from
-scratch.
 
 **Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165) overlaps open PR #142, and [#167](https://github.com/clarkio/wos-plus/issues/167) overlaps open PR #144. For #144 especially — recording a slot as solved *without* also blocking the board save would put an unknown word into the archive, the exact failure #167 rules out.
 

--- a/src/lib/board-utils.ts
+++ b/src/lib/board-utils.ts
@@ -181,6 +181,17 @@ export function normalizeLanguageCode(code: unknown): string | null {
 }
 
 /**
+ * Strips the formatting streamers plausibly type a Twitch channel name with —
+ * a leading '#', surrounding whitespace, mixed case — without judging whether
+ * the result is a valid Twitch username. Shared by `normalizeTwitchChannel`
+ * (below) and the channel-stats read path so both sides of a name written
+ * either way resolve to the same channel (#164).
+ */
+export function cleanTwitchChannel(channel: string): string {
+  return channel.trim().replace(/^#/, '').toLowerCase();
+}
+
+/**
  * Normalizes a Twitch channel name for storage on a board (lowercase, no
  * leading '#'). Returns null when the value isn't a valid Twitch username
  * (letters, digits, underscores, max 50 chars) so callers can simply omit it —
@@ -191,7 +202,7 @@ export function normalizeTwitchChannel(channel: unknown): string | null {
     return null;
   }
 
-  const cleanChannel = channel.trim().replace(/^#/, '').toLowerCase();
+  const cleanChannel = cleanTwitchChannel(channel);
   if (!/^[a-z0-9_]{1,50}$/.test(cleanChannel)) {
     return null;
   }

--- a/src/pages/api/channel-stats/[channel].ts
+++ b/src/pages/api/channel-stats/[channel].ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createClient } from '@supabase/supabase-js';
 import { env } from 'cloudflare:workers';
+import { cleanTwitchChannel } from '../../../lib/board-utils';
 
 export const prerender = false;
 
@@ -24,9 +25,10 @@ export const GET: APIRoute = async ({ params }) => {
   }
 
   // Streamers write channel names both with and without a leading '#'; strip
-  // it here the same way normalizeTwitchChannel does for the board path, so
-  // '#clarkio' and 'clarkio' resolve to the same channel everywhere (#164).
-  const cleanChannel = channel.trim().replace(/^#/, '').toLowerCase();
+  // it here with the same helper normalizeTwitchChannel uses for the board
+  // path, so '#clarkio' and 'clarkio' resolve to the same channel everywhere
+  // (#164).
+  const cleanChannel = cleanTwitchChannel(channel);
 
   if (!/^[a-z0-9_]+$/.test(cleanChannel)) {
     return new Response(JSON.stringify({ error: 'Invalid channel name format. Only lowercase letters, numbers, and underscores are allowed.' }), {


### PR DESCRIPTION
## What changed

Closes #164. `GET /api/channel-stats/[channel]` already stripped a leading `#` from a channel name (matching the board save path), but reimplemented `normalizeTwitchChannel`'s trim/strip-`#`/lowercase transform inline instead of sharing it — the exact duplication `AGENTIC-TESTING-PLAN.md`'s "Where this stands" section flagged as #164's remaining work.

Extracted that transform into a new `cleanTwitchChannel` helper in `src/lib/board-utils.ts`, used by both `normalizeTwitchChannel` (board path) and the channel-stats route. The route keeps its own format/length validation *after* cleaning — not a call to `normalizeTwitchChannel` itself — because the two paths intentionally give different error messages for "bad characters" vs. "too long" while `normalizeTwitchChannel` collapses both into a single `null`. Folding that distinction away would have been an unrelated behaviour change outside #164's scope.

`AGENTIC-TESTING-PLAN.md` § "Where this stands" is updated to record #164 as done and point at #169 as the next behaviour-backlog pick.

## Verification

- [x] Spec in `specs/` added or updated (behavior changes only — see note below) — **N/A**, this is a pure duplication cleanup; the channel-stats route's observable behaviour is unchanged
- [x] Tests written or updated *before or with* the implementation — **N/A**, no new behaviour; the existing `#164` acceptance scenario in `tests/acceptance/channel-stats.acceptance.test.ts` already pinned the correct (post-fix) behaviour and stays green unchanged
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally:
  - `check`: 0 errors, 0 warnings (15 pre-existing hints)
  - `lint`: clean, `--max-warnings 0`
  - `test:coverage`: 673 passed, 4 todo, 19 files — 91.06% stmts / 87.17% branch / 88.26% funcs / 91.76% lines (above thresholds)
  - `build`: succeeds
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

Pure refactor per `CLAUDE.md` §2.5 ("promote rules into tools") in spirit — no behaviour change, no test change. The `[#164 fix]` reference already present elsewhere in `AGENTIC-TESTING-PLAN.md` predated this PR and was inconsistent with the "Note" section that (correctly) said the duplication was still open; that inconsistency is resolved here too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqHvVKH2D4zufEfYXJ4yW3)_