### PR TITLE
File a captured board under the alphabetically last big word (#165)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -30,10 +30,10 @@ describe intent, not status. This section is the status.
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
 
-### The numbers, as of the #169 fix
+### The numbers, as of the #165 fix
 
-**680 passing** tests across 19 files, plus 4 deliberate `it.todo`. Coverage
-**91.23% statements / 87.41% branches / 88.58% functions / 91.9% lines**, counting
+**691 passing** tests across 19 files, plus 3 deliberate `it.todo`. Coverage
+**91.4% statements / 87.77% branches / 88.94% functions / 92.07% lines**, counting
 every file under `src/**/*.ts` so an untested module shows as 0% rather than being
 invisible. `src/scripts/wos-widget.ts` is the one module no test imports.
 
@@ -222,19 +222,47 @@ have been an unrelated behaviour change. No acceptance test changed; the
 written the way a streamer would type it") already pinned the correct
 behaviour and stays green, unchanged.
 
-Sharpest next, affecting streamers today: with #172, #168, #161, #163, #171,
-#162, #164 and #169 done, both issues left —
-[#165](https://github.com/clarkio/wos-plus/issues/165) and
-[#167](https://github.com/clarkio/wos-plus/issues/167) — overlap open **draft**
-PRs rather than being a clean pick. Neither PR has been reconciled against its
-issue's precise approved rule yet, so that reconciliation is the next step, not
-a fresh implementation from scratch.
+**#165 is done** — the reconciliation this section used to point at as the next
+step. Draft PR #142 ("fix: key boards by the alphabetically last big word") was
+checked against #165's precise approved rule — longest, then alphabetically
+last among ties — and found to already implement it correctly: `hitMax` (the
+WoS event flag that sets `currentLevelBigWord`) is only ever true for a guess
+that uses every letter in the level, so every candidate `determineBoardId`
+compares is already the same, maximal length by construction. The "longest"
+half of the rule is therefore structural, not something the implementation
+needed to compute separately — the only real work was the alphabetical
+tie-break, which PR #142 already had right. Rather than reconcile the stale
+draft branch (opened against a much older `main`) via rebase, the fix was
+re-applied directly onto current `main`: `determineBoardId(bigWord,
+extraCandidates)` in `src/scripts/wos-words.ts` picks the alphabetically last
+anagram among the tracked big word, the level's filled slot words, and the
+loaded dictionary; `GameSpectator` (`src/scripts/wos-plus-main.ts`) uses it on
+both save (`handleLevelResults`) and lookup (`logMissingWords`, which retries
+under the guessed big word for boards saved before ids were canonicalized);
+`db-scripts/fix-board-ids.mjs` was updated to target the same canonical id for
+a one-off data migration. Covered by new unit tests in
+`tests/unit/wos-words.test.ts` and `tests/unit/wos-plus-main.test.ts`, and a
+new end-to-end acceptance scenario in `tests/acceptance/game-flow.acceptance.test.ts`
+§ "Ending a level" that guesses two anagrams (RULING, then LURING landing in
+the level's last slot) and asserts the board is captured under `RULING`, not
+the positionally-last guess. The `known gap (#165)` placeholder in
+`tests/acceptance/boards.acceptance.test.ts` was inverted (not deleted) to pin
+the fixed rule directly against `determineBoardId`, since the id resolution
+itself happens before `/api/boards` is ever called and isn't otherwise
+reachable from the route. `specs/boards.md` § "which word a board is filed
+under" is now ✅ Confirmed rather than ⚠️. PR #142 itself was left untouched
+(still open, still against its old base) — the fix landed as new work on top
+of current `main` instead of through that branch; #142 can be closed once this
+lands.
 
-**Check before merging the older PRs:** [#165](https://github.com/clarkio/wos-plus/issues/165)
-overlaps open PR #142 ("fix: key boards by the alphabetically last big word") —
-#165's own text asks that #142 be checked against the *longest-then-alphabetical*
-rule specifically (not just alphabetical) before either is merged; close #165 as
-a duplicate only if #142 already implements exactly that. [#167](https://github.com/clarkio/wos-plus/issues/167)
+Sharpest next, affecting streamers today: with #172, #168, #161, #163, #171,
+#162, #164, #169 and #165 done, one issue is left —
+[#167](https://github.com/clarkio/wos-plus/issues/167) — and it overlaps an
+open **draft** PR rather than being a clean pick. That PR has not been
+reconciled against the issue's precise approved rule yet, so that
+reconciliation is the next step, not a fresh implementation from scratch.
+
+**Check before merging the older PR:** [#167](https://github.com/clarkio/wos-plus/issues/167)
 overlaps open PR #144 ("Record unrecoverable hidden mobile guesses as solved,
 not missed") — #167 asks that #144 be checked for whether it blocks the board
 save as well as counting the clear (the PR's own description describes a

--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -250,10 +250,10 @@ the positionally-last guess. The `known gap (#165)` placeholder in
 the fixed rule directly against `determineBoardId`, since the id resolution
 itself happens before `/api/boards` is ever called and isn't otherwise
 reachable from the route. `specs/boards.md` § "which word a board is filed
-under" is now ✅ Confirmed rather than ⚠️. PR #142 itself was left untouched
-(still open, still against its old base) — the fix landed as new work on top
-of current `main` instead of through that branch; #142 can be closed once this
-lands.
+under" is now ✅ Confirmed rather than ⚠️. Draft PR #142 was closed as
+superseded (with an explanatory comment) rather than reconciled — the fix
+landed as new work on top of current `main` instead of through that stale
+branch.
 
 Sharpest next, affecting streamers today: with #172, #168, #161, #163, #171,
 #162, #164, #169 and #165 done, one issue is left —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Prefer a failing build over a paragraph of good advice.
 
 ## 4. Known state (keep current)
 
-- Test suite: **680 passing** Vitest tests across 19 files, plus **4
+- Test suite: **691 passing** Vitest tests across 19 files, plus **3
   `it.todo`**. Every remaining todo is a **known gap with a tracking issue or a
   stated coverage limitation** — none is simply an unwritten test, and none may
   be deleted to tidy the count. The decisions behind them are tabulated in
@@ -150,8 +150,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **91.23% statements / 87.41% branches / 88.58% functions /
-  91.9% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **91.4% statements / 87.77% branches / 88.94% functions /
+  92.07% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/db-scripts/fix-board-ids.mjs
+++ b/db-scripts/fix-board-ids.mjs
@@ -47,7 +47,9 @@ function parseArgs(argv) {
 }
 
 function usage() {
-  return `Fix boards.id to match last slot word
+  return `Fix boards.id to match the canonical board id: the alphabetically
+last big word of the board (the level can have several big-word anagrams,
+e.g. LURING and RULING, and sessions may have captured any of them).
 
 If an id update fails due to a duplicate key, the script will fetch the existing row
 for the desired id and compare its slots to the mismatched row's slots (by slot "word" values).
@@ -88,16 +90,35 @@ function coerceSlots(slots) {
   return null;
 }
 
-function getLastSlotWord(slotsArray) {
+// The canonical board id is the alphabetically last big word (see
+// determineBoardId in src/scripts/wos-words.ts). Candidates are the row's
+// max-length slot words plus the row's current id when it is itself an
+// anagram of them — so a row that is already keyed canonically (e.g. RULING)
+// is never re-keyed back to an alphabetically earlier anagram that happened
+// to be captured in its slots (e.g. LURING in the last slot).
+function getDesiredBoardId(currentIdNorm, slotsArray) {
   if (!Array.isArray(slotsArray) || slotsArray.length === 0) return null;
-  const last = slotsArray[slotsArray.length - 1];
-  if (!last || typeof last !== "object") return null;
 
-  if (typeof last.word === "string" && last.word.trim().length > 0) {
-    return last.word;
+  const words = slotsArray
+    .map((slot) => (slot && typeof slot === "object" ? slot.word : null))
+    .map((word) => normalizeId(word))
+    .filter(Boolean);
+
+  if (words.length === 0) return null;
+
+  const maxLength = Math.max(...words.map((word) => word.length));
+  const candidates = new Set(words.filter((word) => word.length === maxLength));
+
+  const signature = [...candidates][0].split("").sort().join("");
+  if (
+    currentIdNorm &&
+    currentIdNorm.length === maxLength &&
+    currentIdNorm.split("").sort().join("") === signature
+  ) {
+    candidates.add(currentIdNorm);
   }
 
-  return null;
+  return [...candidates].sort((a, b) => a.localeCompare(b)).pop();
 }
 
 function isDuplicateKeyError(error) {
@@ -309,17 +330,13 @@ async function main() {
 
       const currentId = row?.id;
       const slotsArray = coerceSlots(row?.slots);
-      const lastWord = getLastSlotWord(slotsArray);
-
-      if (!currentId || !lastWord) {
-        skipped += 1;
-        continue;
-      }
 
       const currentIdNorm = normalizeId(currentId);
-      const desiredIdNorm = normalizeId(lastWord);
+      const desiredIdNorm = currentIdNorm
+        ? getDesiredBoardId(currentIdNorm, slotsArray)
+        : null;
 
-      if (!desiredIdNorm) {
+      if (!currentIdNorm || !desiredIdNorm) {
         skipped += 1;
         continue;
       }
@@ -327,7 +344,7 @@ async function main() {
       if (currentIdNorm !== desiredIdNorm) {
         mismatched += 1;
         console.log(
-          `Mismatch: id=${currentIdNorm} -> slots[last].word=${desiredIdNorm}`
+          `Mismatch: id=${currentIdNorm} -> canonical big word=${desiredIdNorm}`
         );
 
         if (args.apply) {

--- a/specs/README.md
+++ b/specs/README.md
@@ -134,7 +134,7 @@ behaviour, so implementing one forces its test to be inverted deliberately.
 | Was | Decision | Issue |
 | --- | --- | --- |
 | B1, B2 | The board **save** path must apply the same name, slot and completeness guards as lookup and repair. Today it applies only the repeated-word rule. | [#162](https://github.com/clarkio/wos-plus/issues/162) |
-| B3 | A board is filed under the **longest** word on it, alphabetically last among ties — not the last slot's word. | [#165](https://github.com/clarkio/wos-plus/issues/165) |
+| ~~B3~~ | ~~A board is filed under the **longest** word on it, alphabetically last among ties — not the last slot's word.~~ **Fixed** — `determineBoardId` in `wos-words.ts`, used by `GameSpectator` on both save and lookup. Per [#165](https://github.com/clarkio/wos-plus/issues/165). |
 | G2 | An unrecoverable masked guess **counts as a clear**, but **blocks the board save**. Two outcomes, deliberately decoupled. | [#167](https://github.com/clarkio/wos-plus/issues/167) |
 
 **Confirmed — current behaviour is intended.** No work; the reasoning is

--- a/specs/boards.md
+++ b/specs/boards.md
@@ -390,10 +390,17 @@ must hold to the same rules as every other.
   deterministic tie-break the same board would be filed under a different name
   on different nights, splitting one board into two half-true archive entries.
 
-> ⚠️ **Approved, not yet implemented** — WoS+ today files the capture under the
-> word in the board's *last slot*, which is a positional guess at the same
-> thing. Tracked by [#165](https://github.com/clarkio/wos-plus/issues/165); open
-> PR #142 may already cover part of it.
+> ✅ **Confirmed (maintainer)** — implemented in
+> [#165](https://github.com/clarkio/wos-plus/issues/165). `determineBoardId` in
+> `src/scripts/wos-words.ts` picks the alphabetically last anagram among the
+> tracked big word, the level's filled slot words, and the loaded dictionary,
+> instead of trusting whichever word happens to sit in the board's last slot.
+> `GameSpectator` uses it on both save (`handleLevelResults`) and lookup
+> (`logMissingWords`, retrying under the guessed big word for boards saved
+> before ids were canonicalized). Because a level's tracked big word is always
+> derived from a `hitMax` guess (one that uses every letter), every candidate
+> this compares is already the same, maximal length — so "longest" is
+> structural and the remaining work is exactly the alphabetical tie-break.
 
 ---
 

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -1,7 +1,7 @@
 import tmi, { type Client as tmiClient } from '@tmi.js/chat';
 import io from 'socket.io-client';
 
-import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord } from './wos-words';
+import { findAllMissingWords, findMissingWordsFromBoard, loadWordsFromDb, isWosWord, canFormWord, determineBoardId } from './wos-words';
 import { saveBoard, fetchBoard, fetchChannelStats } from './db-service';
 import { getMirrorGameId } from './mirror-url';
 import { wosLanguageIdToCode } from '../lib/board-utils';
@@ -373,11 +373,13 @@ export class GameSpectator {
       // Capture board data
       if (this.currentLevelBigWord && this.currentLevelSlots) {
         console.log('[WOS Helper] Saving board data to database...');
-        console.log('[WOS Helper] Board ID:', this.currentLevelBigWord);
+        // Save under the canonical id (the alphabetically last big word) —
+        // not whichever anagram happened to be guessed or to sit in the
+        // game's last slot, both of which vary per session.
+        const boardId = this.determineBoardId();
+        console.log('[WOS Helper] Board ID:', boardId);
         console.log('[WOS Helper] Board Slots:', this.currentLevelSlots);
-        const slots = this.currentLevelSlots;
-        if (slots[slots.length - 1].word !== this.currentLevelBigWord) this.currentLevelBigWord = slots[slots.length - 1].word;
-        await saveBoard(this.currentLevelBigWord, this.currentLevelSlots, this.currentChannel, this.currentLanguageCode);
+        await saveBoard(boardId, this.currentLevelSlots, this.currentChannel, this.currentLanguageCode);
       }
 
       this.playSound('level_clear');
@@ -551,8 +553,21 @@ export class GameSpectator {
 
     // Try to fetch board data if we have a big word
     if (this.currentLevelBigWord !== '') {
-      console.log('Attempting to fetch board with ID:', this.currentLevelBigWord);
-      const board = await fetchBoard(this.currentLevelBigWord);
+      // Look the board up under its canonical id (the alphabetically last big
+      // word): the guessed big word may be a different anagram of the id the
+      // board was stored under (e.g. LURING guessed, board saved as RULING).
+      const boardId = this.determineBoardId();
+      console.log('Attempting to fetch board with ID:', boardId);
+      let board = await fetchBoard(boardId);
+
+      // Boards saved before ids were canonicalized are keyed by whichever big
+      // word that session happened to capture, so retry with the guessed word
+      // before falling back to dictionary-based detection.
+      const guessedBoardId = this.currentLevelBigWord.replace(/\s+/g, '').toUpperCase();
+      if (!board && guessedBoardId !== boardId) {
+        console.log('Board not found under canonical ID, retrying with guessed big word:', guessedBoardId);
+        board = await fetchBoard(guessedBoardId);
+      }
 
       if (board && board.slots) {
         console.log('Board found in database, using board slots for missed words detection');
@@ -760,6 +775,17 @@ export class GameSpectator {
           this.currentLevelHiddenLetters.map(l => l.toUpperCase()).join(' ');
       }
     }
+  }
+
+  // Canonical database id for the current board: the alphabetically last big
+  // word of the level. Filled slot words are passed as extra candidates so a
+  // big-word anagram captured in a slot still wins even when the dictionary
+  // hasn't loaded (determineBoardId ignores non-anagram words).
+  private determineBoardId(): string {
+    const slotWords = this.currentLevelSlots
+      .filter(slot => typeof slot.word === 'string' && slot.word.length > 0)
+      .map(slot => slot.word);
+    return determineBoardId(this.currentLevelBigWord, slotWords);
   }
 
   private updateCurrentLevelSlots(username: string, letters: string[], index: number, hitMax: boolean) {

--- a/src/scripts/wos-words.ts
+++ b/src/scripts/wos-words.ts
@@ -66,6 +66,49 @@ export interface Slot {
   length?: number;
 }
 
+/**
+ * Determines the canonical database id for a board: the alphabetically last
+ * big word of the level. A level can have several valid big words — anagrams
+ * of the same letters, e.g. LURING and RULING — and which one players happen
+ * to guess (or which one lands in the game's final slot) varies per session.
+ * Keying boards by the anagram that sorts last alphabetically makes every
+ * session derive the same id for the same board, on save and on lookup.
+ *
+ * Candidates are the dictionary anagrams of `bigWord` plus any
+ * `extraCandidates` observed during play (e.g. filled slot words); candidates
+ * that aren't anagrams of `bigWord` are ignored. Falls back to `bigWord`
+ * itself when the dictionary hasn't loaded and nothing else qualifies.
+ * Returns the id uppercased with any display spaces removed.
+ */
+export function determineBoardId(bigWord: string, extraCandidates: string[] = []): string {
+  const cleanBigWord = bigWord.replace(/\s+/g, '').toLowerCase();
+  if (cleanBigWord.length === 0) {
+    return '';
+  }
+
+  const signature = cleanBigWord.split('').sort().join('');
+  const isAnagram = (word: string) =>
+    word.length === cleanBigWord.length && word.split('').sort().join('') === signature;
+
+  const candidates = new Set<string>([cleanBigWord]);
+
+  for (const candidate of extraCandidates) {
+    const clean = candidate.replace(/\s+/g, '').toLowerCase();
+    if (isAnagram(clean)) {
+      candidates.add(clean);
+    }
+  }
+
+  for (const word of wosDictionary) {
+    const clean = word.toLowerCase();
+    if (isAnagram(clean)) {
+      candidates.add(clean);
+    }
+  }
+
+  return [...candidates].sort((a, b) => a.localeCompare(b)).pop()!.toUpperCase();
+}
+
 export async function loadWordsFromDb() {
   try {
     const url = '/api/words';

--- a/tests/acceptance/boards.acceptance.test.ts
+++ b/tests/acceptance/boards.acceptance.test.ts
@@ -1951,19 +1951,28 @@ describe('specs/boards.md — approved changes not yet implemented (current beha
 
   describe('Scenario: the big word disagrees with the last slot', () => {
     // Given a level is being captured
-    // And the big word WoS+ tracked during the level is not the word in the
-    //     board's last slot
+    // And the level has several anagram big words (e.g. LURING and RULING)
     // When the board is captured
-    // Then the board is filed under the *last slot's* word instead of the
-    //      tracked big word
+    // Then the board is filed under the longest word, and among ties at that
+    //      length, the alphabetically last of them — never a positional guess
+    //      at whichever word happens to sit in the last slot
 
-    it.todo(
-      'known gap (#165): a capture is filed under the last slot word rather than the longest, ' +
-      'alphabetically-last word the maintainer approved as the board identity. ' +
-      'Not reachable from /api/boards: the substitution happens in the capture path in ' +
-      'src/scripts/wos-plus-main.ts before the route is called, and the route stores the id it is ' +
-      'given. Belongs with the game-flow work (specs/game-flow.md)',
-    );
+    it('#165 landed: the id is the alphabetically last anagram, not the last slot\'s word', async () => {
+      // Not reachable from /api/boards: the id is resolved in the capture path
+      // (GameSpectator.determineBoardId, src/scripts/wos-plus-main.ts) before
+      // the route is ever called — the route stores whatever id it is given.
+      // The end-to-end capture is exercised in
+      // tests/acceptance/game-flow.acceptance.test.ts § "Ending a level"
+      // ("captures the board under the alphabetically last big word, not
+      // whichever anagram sits in the last slot (#165)"); this pins the
+      // canonicalization rule itself directly against the module the route
+      // trusts to have already produced the right id.
+      const { determineBoardId } = await import('../../src/scripts/wos-words');
+
+      // LURING sits in the last slot (mirroring the pre-#165 positional bug),
+      // but RULING is the alphabetically last anagram and must win.
+      expect(determineBoardId('LURING', ['ring', 'ruling', 'luring'])).toBe('RULING');
+    });
   });
 
   describe('Scenario: a very large archive', () => {

--- a/tests/acceptance/game-flow.acceptance.test.ts
+++ b/tests/acceptance/game-flow.acceptance.test.ts
@@ -1262,6 +1262,33 @@ describe('specs/game-flow.md § Ending a level', () => {
     expect(capture.posted[0]).toMatchObject({ language_code: 'fr' });
   });
 
+  it('captures the board under the alphabetically last big word, not whichever anagram sits in the last slot (#165)', async () => {
+    // LURING and RULING are anagrams of the same 6 letters, so either one can
+    // report hitMax:true (the actual per-slot completion flag) depending on
+    // which slot gets solved. RULING is guessed first (setting the tracked big
+    // word), then LURING is guessed second — landing in the level's *last*
+    // slot and re-tracking the big word as LURING. The pre-#165 behaviour
+    // trusted whichever word ended up in the last slot; the approved rule is
+    // deterministic regardless of slot order: the longest word, and among
+    // ties, the alphabetically last — RULING, not LURING.
+    const capture = boardCaptureRecorder();
+    server.use(boardNotArchived(), capture.handler);
+
+    await playWosEvent(levelStarted({
+      level: 3,
+      letters: ['l', 'u', 'r', 'i', 'n', 'g'],
+      slotLengths: [4, 6, 6],
+    }));
+    await playWosEvent(correctGuess({ user: 'clarkio', word: 'ring', index: 0 }));
+    await playWosEvent(correctGuess({ user: 'biocow', word: 'ruling', index: 1, hitMax: true }));
+    await playWosEvent(correctGuess({ user: 'smc_may_i', word: 'luring', index: 2, hitMax: true }));
+
+    await playWosEvent(levelResults(5));
+
+    expect(capture.posted).toHaveLength(1);
+    expect(capture.posted[0]).toMatchObject({ id: 'RULING' });
+  });
+
   it('treats five stars as a clear even with a slot nobody filled', async () => {
     server.use(boardNotArchived());
 

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -28,6 +28,10 @@ vi.mock('@scripts/wos-words', async (importActual) => {
     // dependency, so hidden-word resolution genuinely validates that a candidate
     // fits within the level's letters.
     canFormWord: actual.canFormWord,
+    // Keep the real board-id canonicalization too: with the dictionary unloaded
+    // in tests it works purely from the big word and the slot-word candidates,
+    // so save/fetch key derivation is genuinely exercised.
+    determineBoardId: actual.determineBoardId,
   };
 });
 
@@ -1040,6 +1044,30 @@ describe('GameSpectator class', () => {
       expect(document.getElementById('level-title')!.innerText).toBe('NEXT LEVEL');
       expect(document.getElementById('level-value')!.innerText).toBe('13');
     });
+
+    it('should save a cleared board under the alphabetically last big word', async () => {
+      // The level has two big words (anagrams LURING and RULING). LURING was
+      // the guessed big word and also sits in the game's last slot, but the
+      // canonical board id must be RULING — the alphabetically last anagram.
+      const dbService = await import('@scripts/db-service');
+      const saveBoardMock = vi.mocked(dbService.saveBoard);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'i', 'n', 'g'], word: 'ring', user: 'user1', hitMax: false, index: 0, length: 4 },
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user2', hitMax: true, index: 1, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: 'luring', user: 'user3', hitMax: true, index: 2, length: 6 },
+      ];
+
+      await (spectator as any).handleLevelResults(5);
+
+      expect(saveBoardMock).toHaveBeenCalledWith(
+        'RULING',
+        spectator.currentLevelSlots,
+        spectator.currentChannel,
+        spectator.currentLanguageCode
+      );
+    });
   });
 
   describe('handleLevelEnd', () => {
@@ -1297,7 +1325,9 @@ describe('GameSpectator class', () => {
 
       await (spectator as any).logMissingWords();
 
-      expect(fetchBoardMock).toHaveBeenCalledWith('T E S T I N G');
+      // The board is looked up under its canonical id: spaces removed,
+      // alphabetically last anagram.
+      expect(fetchBoardMock).toHaveBeenCalledWith('TESTING');
       expect(findAllMissingWordsMock).toHaveBeenCalledTimes(1);
       expect(spectator.currentLevelCorrectWords).toEqual(
         expect.arrayContaining(['alpha*', 'beta*'])
@@ -1373,13 +1403,71 @@ describe('GameSpectator class', () => {
 
       await (spectator as any).logMissingWords();
 
-      expect(fetchBoardMock).toHaveBeenCalledWith('T E S T I N G');
+      expect(fetchBoardMock).toHaveBeenCalledWith('TESTING');
       expect(findMissingWordsFromBoardMock).toHaveBeenCalledWith(
         spectator.currentLevelSlots,
         mockBoard.slots
       );
       expect(spectator.currentLevelCorrectWords).toEqual(
         expect.arrayContaining(['miss*'])
+      );
+    });
+
+    it('should fetch the board under the alphabetically last big word anagram', async () => {
+      // RULING was captured in a slot while LURING is the guessed big word:
+      // the lookup must use RULING, the canonical (alphabetically last) id.
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      fetchBoardMock.mockResolvedValueOnce({
+        id: 'RULING',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [],
+      });
+      vi.mocked(wosWords.findMissingWordsFromBoard).mockReturnValueOnce([]);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user1', hitMax: true, index: 0, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: '', hitMax: false, index: 1, length: 6 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(fetchBoardMock).toHaveBeenCalledTimes(1);
+      expect(fetchBoardMock).toHaveBeenCalledWith('RULING');
+    });
+
+    it('should retry the fetch with the guessed big word when the canonical id is not stored', async () => {
+      // Boards saved before ids were canonicalized are keyed by whichever big
+      // word that session captured — here the board is stored as LURING.
+      const dbService = await import('@scripts/db-service');
+      const fetchBoardMock = vi.mocked(dbService.fetchBoard);
+      const legacyBoard = {
+        id: 'LURING',
+        created_at: '2024-01-01T00:00:00Z',
+        slots: [
+          { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: 'luring', user: 'user1', hitMax: true, index: 0, length: 6 },
+        ],
+      };
+      fetchBoardMock.mockResolvedValueOnce(null); // canonical id RULING not found
+      fetchBoardMock.mockResolvedValueOnce(legacyBoard);
+
+      const findMissingWordsFromBoardMock = vi.mocked(wosWords.findMissingWordsFromBoard);
+      findMissingWordsFromBoardMock.mockReturnValueOnce([]);
+
+      spectator.currentLevelBigWord = 'L U R I N G';
+      spectator.currentLevelSlots = [
+        { letters: ['r', 'u', 'l', 'i', 'n', 'g'], word: 'ruling', user: 'user1', hitMax: true, index: 0, length: 6 },
+        { letters: ['l', 'u', 'r', 'i', 'n', 'g'], word: '', hitMax: false, index: 1, length: 6 },
+      ];
+
+      await (spectator as any).logMissingWords();
+
+      expect(fetchBoardMock).toHaveBeenNthCalledWith(1, 'RULING');
+      expect(fetchBoardMock).toHaveBeenNthCalledWith(2, 'LURING');
+      expect(findMissingWordsFromBoardMock).toHaveBeenCalledWith(
+        spectator.currentLevelSlots,
+        legacyBoard.slots
       );
     });
 

--- a/tests/unit/wos-words.test.ts
+++ b/tests/unit/wos-words.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { findMissingWordsFromBoard, canFormWord } from '@scripts/wos-words';
+import { findMissingWordsFromBoard, canFormWord, determineBoardId } from '@scripts/wos-words';
 import type { Slot } from '@scripts/wos-words';
 
 /**
@@ -332,6 +332,40 @@ describe('wos-words module', () => {
 
       // Assert
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('determineBoardId', () => {
+    it('should return the big word itself when no other candidates exist', () => {
+      expect(determineBoardId('TESTING')).toBe('TESTING');
+    });
+
+    it('should strip display spaces and uppercase the id', () => {
+      expect(determineBoardId('l u r i n g')).toBe('LURING');
+    });
+
+    it('should return empty string for an empty big word', () => {
+      expect(determineBoardId('')).toBe('');
+      expect(determineBoardId('   ')).toBe('');
+    });
+
+    it('should pick the alphabetically last anagram among extra candidates', () => {
+      expect(determineBoardId('L U R I N G', ['ruling'])).toBe('RULING');
+      // Order of arguments must not matter — RULING wins either way.
+      expect(determineBoardId('RULING', ['luring'])).toBe('RULING');
+    });
+
+    it('should ignore extra candidates that are not anagrams of the big word', () => {
+      expect(determineBoardId('LURING', ['ring', 'unruly', 'zzzzzz'])).toBe('LURING');
+    });
+
+    it('should pick the alphabetically last anagram from the loaded dictionary', async () => {
+      // Seed the module's dictionary the same way production does.
+      const wosWords = await importModuleWithDictionary(['luring', 'ruling', 'unrig', 'ring']);
+
+      // RULING was never guessed nor passed as a candidate, but the
+      // dictionary knows it is an anagram of LURING and it sorts last.
+      expect(wosWords.determineBoardId('L U R I N G')).toBe('RULING');
     });
   });
 


### PR DESCRIPTION
## What changed

Resolves [#165](https://github.com/clarkio/wos-plus/issues/165) (open question B3 from the #160 review): a level can have several anagram big words (e.g. `LURING`/`RULING`), and the board id was resolved positionally — whichever anagram happened to sit in the game's last slot, order-dependent across sessions. `determineBoardId()` in `src/scripts/wos-words.ts` now picks the id deterministically: the alphabetically last anagram among the tracked big word, the level's filled slot words, and the loaded dictionary. `GameSpectator` uses it on both save (`handleLevelResults`) and lookup (`logMissingWords`, retrying under the guessed big word for boards saved before ids were canonicalized). `db-scripts/fix-board-ids.mjs` was updated to target the same canonical id for a one-off data migration.

Because a level's tracked big word is only ever set from a `hitMax` guess (one that uses every letter), every candidate this compares is already the same, maximal length — so "longest" is structural and the remaining work is exactly the alphabetical tie-break the issue asks for.

**Relationship to PR #142:** draft PR #142 ("fix: key boards by the alphabetically last big word") already implemented this rule correctly, but its branch was based on a much older `main` and predated roughly a dozen since-merged fixes. Rather than rebase that stale branch, this PR re-applies the same fix directly onto current `main`. #142 has been closed as superseded by this PR.

## Verification

- [x] Spec in `specs/` added or updated — `specs/boards.md` § "which word a board is filed under" is now ✅ Confirmed rather than ⚠️; `specs/README.md` § Decisions from the #160 review marks B3 fixed
- [x] Tests written or updated *before or with* the implementation
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally (691 passing, 3 `it.todo`; coverage 91.4% / 87.77% / 88.94% / 92.07%, above the enforced thresholds)
- [x] No existing test weakened, skipped, or deleted — the `known gap (#165)` `it.todo` in `tests/acceptance/boards.acceptance.test.ts` was inverted into a real, passing test (not reachable at the route level, so it asserts directly against `determineBoardId`, the module the route trusts to have already produced the right id); a full end-to-end scenario was also added to `tests/acceptance/game-flow.acceptance.test.ts`
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

- `AGENTIC-TESTING-PLAN.md` § "Where this stands" is updated to record #165 as done and to name #167 (overlapping draft PR #144) as the one remaining item from the #160-review behaviour backlog.
- `CLAUDE.md` § 4 test/coverage numbers refreshed to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBs7ZWUmnsiSaBq8nLKLoz)_