### PR TITLE
Count an unrecoverable masked guess as a clear without saving the board (#167)

### DIFF
--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -30,10 +30,10 @@ describe intent, not status. This section is the status.
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
 
-### The numbers, as of the #165 fix
+### The numbers, as of the #167 fix
 
-**691 passing** tests across 19 files, plus 3 deliberate `it.todo`. Coverage
-**91.4% statements / 87.77% branches / 88.94% functions / 92.07% lines**, counting
+**692 passing** tests across 19 files, plus 3 deliberate `it.todo`. Coverage
+**91.41% statements / 87.77% branches / 88.94% functions / 92.08% lines**, counting
 every file under `src/**/*.ts` so an untested module shows as 0% rather than being
 invisible. `src/scripts/wos-widget.ts` is the one module no test imports.
 
@@ -49,9 +49,9 @@ branches 85, functions 86, lines 90) plus per-file floors for `wos-words.ts` and
 verified by temporarily raising a threshold above measured reality and watching
 the run fail, then reverting.
 
-Next: the **behaviour issues** below, which include live defects. Then #153 (cheap,
-workflow files only), then #154. #152 last or never — `wrangler dev` may not run in
-a sandbox at all.
+The **behaviour issues** below (all thirteen from the #160 review) are now done.
+Next: #153 (cheap, workflow files only), then #154. #152 last or never —
+`wrangler dev` may not run in a sandbox at all.
 
 **Two need maintainer sign-off before starting**, per `CLAUDE.md` §2.3: #152 adds
 Playwright and #154 adds StrykerJS.
@@ -72,8 +72,10 @@ Thirteen issues, all approved by the maintainer:
 [#169](https://github.com/clarkio/wos-plus/issues/169) are done** (PR
 [#176](https://github.com/clarkio/wos-plus/pull/176), the #170 fix, the
 #166 fix, the #164 fix, the #168 fix, the #161 fix, the #163 fix, the
-#171 fix, the #162 fix and the #169 fix) — two remain, both overlapping open
-draft PRs (see below).
+#171 fix, the #162 fix and the #169 fix). **[#165](https://github.com/clarkio/wos-plus/issues/165)
+and [#167](https://github.com/clarkio/wos-plus/issues/167) are also done** —
+the two that overlapped stale open draft PRs (#142 and #144 respectively; see
+below). All thirteen issues from the #160 review are now closed.
 
 **#169 is done** — the WOS socket's `reconnect` event (fired by socket.io only
 after a previously-connected socket recovers, never on the initial connect)
@@ -255,22 +257,47 @@ superseded (with an explanatory comment) rather than reconciled — the fix
 landed as new work on top of current `main` instead of through that stale
 branch.
 
-Sharpest next, affecting streamers today: with #172, #168, #161, #163, #171,
-#162, #164, #169 and #165 done, one issue is left —
-[#167](https://github.com/clarkio/wos-plus/issues/167) — and it overlaps an
-open **draft** PR rather than being a clean pick. That PR has not been
-reconciled against the issue's precise approved rule yet, so that
-reconciliation is the next step, not a fresh implementation from scratch.
+**#167 is done** — all thirteen issues from the #160 review are now closed.
+`updateGameState` in `src/scripts/wos-plus-main.ts` no longer drops an
+unrecoverable masked guess: it still records the slot via
+`updateCurrentLevelSlots`, but with masked (`'?'`-filled) `letters`/`word`
+rather than a resolved word. That single change gets both approved outcomes
+for free, because of how they were already wired: `slot.user` being truthy
+is what `currentLevelSlots.every(slot => slot.user)` (clear detection) and
+`findMissingWordsFromBoard`'s `!currentSlot.user` check (missed-word
+exclusion) both key off, and `saveBoard`'s existing
+`slot.letters.includes('?')` guard (`db-service.ts`) already refuses to
+persist a masked slot — so the board-capture block needed no new code at
+all, only for the slot to stop being silently dropped. Two other acceptance
+scenarios that incidentally asserted `slot.user` stayed `undefined` after an
+unresolved masked guess (`does not choose a word that is already on the
+board`, and the renamed `records the slot masked and says so when no chat
+message can be the word (#167)`) were updated in the same PR, since they
+encoded the same pre-#167 behaviour without being marked as the `known gap`.
+Covered by a new unit test in `tests/unit/wos-plus-main.test.ts` §
+`updateGameState` and the inverted acceptance test in
+`tests/acceptance/game-flow.acceptance.test.ts` § Masked guesses.
+`specs/game-flow.md` § "no matching chat message" is now ✅ Confirmed rather
+than the removed ⚠️ "a masked guess that cannot be recovered" scenario.
 
-**Check before merging the older PR:** [#167](https://github.com/clarkio/wos-plus/issues/167)
-overlaps open PR #144 ("Record unrecoverable hidden mobile guesses as solved,
-not missed") — #167 asks that #144 be checked for whether it blocks the board
-save as well as counting the clear (the PR's own description describes a
-`saveBoard` guard that appears to do this, but per #167 that needs explicit
-confirmation, not an assumption, before merging or closing as duplicate). For
-#144 especially — recording a slot as solved *without* also blocking the board
-save would put an unknown word into the archive, the exact failure #167 rules
-out.
+Draft PR #144 ("Record unrecoverable hidden mobile guesses as solved, not
+missed") was the open PR #167 pointed at for reconciliation. Its description
+already outlined the same `saveBoard`-guard approach, but the branch was
+opened against a much older `main` (July 18) and never rebased — the same
+staleness #165 hit with PR #142. Rather than reconcile it, the fix landed as
+new work directly on current `main`, and #144 was closed as superseded with
+an explanatory comment, mirroring how #142 was handled. #144's broader mobile
+scope (issue #143 — masked guesses from `play.wos.gg`, and reconciling a
+masked slot once WoS reveals it) was **not** re-implemented; only the #167
+slice (decoupling clear detection from board capture) was in scope here. If
+#143's wider mobile-guess handling is still wanted, it needs a fresh issue or
+PR against current `main`, not a revival of #144.
+
+With all thirteen #160-review issues closed, the next open items are #153
+(security & supply-chain gates — cheap, workflow files only) and #154
+(mutation testing, needs maintainer sign-off for the StrykerJS dependency per
+`CLAUDE.md` §2.3). #152 (Playwright E2E) stays last or never, per the
+existing sandbox caveat below.
 
 ### Where the rest of the state lives
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Prefer a failing build over a paragraph of good advice.
 
 ## 4. Known state (keep current)
 
-- Test suite: **691 passing** Vitest tests across 19 files, plus **3
+- Test suite: **692 passing** Vitest tests across 19 files, plus **3
   `it.todo`**. Every remaining todo is a **known gap with a tracking issue or a
   stated coverage limitation** — none is simply an unwritten test, and none may
   be deleted to tidy the count. The decisions behind them are tabulated in
@@ -150,8 +150,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **91.4% statements / 87.77% branches / 88.94% functions /
-  92.07% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **91.41% statements / 87.77% branches / 88.94% functions /
+  92.08% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/specs/README.md
+++ b/specs/README.md
@@ -135,7 +135,7 @@ behaviour, so implementing one forces its test to be inverted deliberately.
 | --- | --- | --- |
 | B1, B2 | The board **save** path must apply the same name, slot and completeness guards as lookup and repair. Today it applies only the repeated-word rule. | [#162](https://github.com/clarkio/wos-plus/issues/162) |
 | ~~B3~~ | ~~A board is filed under the **longest** word on it, alphabetically last among ties — not the last slot's word.~~ **Fixed** — `determineBoardId` in `wos-words.ts`, used by `GameSpectator` on both save and lookup. Per [#165](https://github.com/clarkio/wos-plus/issues/165). |
-| G2 | An unrecoverable masked guess **counts as a clear**, but **blocks the board save**. Two outcomes, deliberately decoupled. | [#167](https://github.com/clarkio/wos-plus/issues/167) |
+| ~~G2~~ | ~~An unrecoverable masked guess **counts as a clear**, but **blocks the board save**. Two outcomes, deliberately decoupled.~~ **Fixed** — `updateGameState` in `wos-plus-main.ts` records the slot masked (filled, word unknown) instead of dropping it; `saveBoard`'s existing `?`-bearing-slot guard keeps it out of the boards table. Per [#167](https://github.com/clarkio/wos-plus/issues/167). |
 
 **Confirmed — current behaviour is intended.** No work; the reasoning is
 recorded in the spec so these are not raised again.

--- a/specs/game-flow.md
+++ b/specs/game-flow.md
@@ -304,8 +304,24 @@ word from what that player typed in chat.
 
 - **Given** `clarkio` typed nothing of the right length that could be the word
 - **When** a masked guess from `clarkio` is reported
-- **Then** WoS+ notes it could not work out the word, nothing is added to the
-  found words, and the slot stays empty
+- **Then** WoS+ notes it could not work out the word, and nothing is added to
+  the found words
+- **And** the slot is still recorded as filled by `clarkio`, masked, so the
+  level can still count as a clear — but the word stays unknown, so it is not
+  reported as missed and the slot's word can never enter a saved board
+
+> ✅ **Confirmed (maintainer)**, implemented in
+> [#167](https://github.com/clarkio/wos-plus/issues/167) — a slot filled by an
+> unrecoverable masked guess counts as filled (the clear is credited, the word
+> is not reported missed), but the board is **not** saved or updated, because
+> one of its words is not known. These two outcomes are deliberately decoupled:
+> a player really did fill that slot, so the clear is real, but WoS+ cannot say
+> *which* word filled it, and a board with a blank/masked word must never enter
+> the archive — every future level would read that back as truth. Draft PR #144
+> was closed as superseded; the fix landed as new work on `main` instead
+> (`updateGameState` in `wos-plus-main.ts` records the slot masked rather than
+> dropping it, and `saveBoard`'s existing `?`-bearing-slot guard keeps it out of
+> the boards table).
 
 ### Scenario: only the last messages a player typed are considered
 
@@ -436,26 +452,6 @@ word from what that player typed in chat.
 ---
 
 ## Approved, not yet implemented
-
-### Scenario: a masked guess that cannot be recovered
-
-- **Given** a masked guess arrives that WoS+ cannot match to any chat message
-- **And** it was the last slot on the board to be filled
-- **When** the level ends
-- **Then** the slot counts as filled, so the level counts as a clear, and the
-  word is not reported as missed
-- **And** the board is **not** saved or updated, because one of its words is not
-  known
-
-  These two outcomes are deliberately decoupled. A player really did fill that
-  slot, so the clear is real and must be credited. But WoS+ cannot say *which*
-  word filled it, and a board with a blank word must never enter the archive —
-  every future level would read that blank back as truth.
-
-> ⚠️ **Approved, not yet implemented** — WoS+ today treats the slot as never
-> filled, which loses the clear *and* reports the word as missed. Tracked by
-> [#167](https://github.com/clarkio/wos-plus/issues/167); open PR #144 may
-> already cover part of it.
 
 ### Scenario: a masked guess longer than a word can be
 

--- a/src/scripts/wos-plus-main.ts
+++ b/src/scripts/wos-plus-main.ts
@@ -638,7 +638,13 @@ export class GameSpectator {
           `[WOS Helper] Could not find matching message for ${lowerUsername}`,
           `[WOS Helper] Chat history: ${JSON.stringify(this.twitchChatLog.get(lowerUsername))}`
         );
-        return; // Skip updating UI if we can't find the word
+        // Approved (#167): the slot still counts as filled — the level can be
+        // a clear and the word is not reported as missed — but the word
+        // itself is unrecoverable, so the slot is recorded masked rather than
+        // left empty. A masked slot's `letters`/`word` still contain '?', so
+        // `saveBoard`'s isMissingWords guard keeps it out of the boards table.
+        this.updateCurrentLevelSlots(username, new Array(letters.length).fill('?'), index, hitMax);
+        return;
       }
     }
 

--- a/tests/acceptance/game-flow.acceptance.test.ts
+++ b/tests/acceptance/game-flow.acceptance.test.ts
@@ -970,13 +970,15 @@ describe('specs/game-flow.md § Masked guesses', () => {
 
     await playWosEvent(maskedGuess({ user: 'clarkio', length: 6, index: 1 }));
 
-    // The game does not accept a word already on the board, so this is not it.
+    // The game does not accept a word already on the board, so this is not
+    // it — the word stays unrecoverable. Per #167, the slot still counts as
+    // filled (masked), but not with the already-placed word.
     expect(foundWords()).toEqual(['ACTION']);
-    expect(spectator.currentLevelSlots[1].user).toBeUndefined();
-    expect(spectator.currentLevelSlots[1].word).toBe('');
+    expect(spectator.currentLevelSlots[1].user).toBe('clarkio');
+    expect(spectator.currentLevelSlots[1].word).toBe('??????');
   });
 
-  it('leaves the slot empty and says so when no chat message can be the word', async () => {
+  it('records the slot masked and says so when no chat message can be the word (#167)', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => { });
     await startTrilbyLevel();
     // Nothing of the right length.
@@ -984,8 +986,12 @@ describe('specs/game-flow.md § Masked guesses', () => {
 
     await playWosEvent(maskedGuess({ user: 'clarkio', length: 6, index: 0 }));
 
+    // The word itself is unrecoverable, so it is not added to the found-words
+    // log — but the slot is still attributed to the player who filled it
+    // rather than left empty (#167).
     expect(foundWords()).toEqual([]);
-    expect(spectator.currentLevelSlots[0].user).toBeUndefined();
+    expect(spectator.currentLevelSlots[0].user).toBe('clarkio');
+    expect(spectator.currentLevelSlots[0].word).toBe('??????');
     expect(warn.mock.calls.flat().join(' ')).toContain(
       'Could not find matching message for clarkio',
     );
@@ -1028,17 +1034,12 @@ describe('specs/game-flow.md § Masked guesses', () => {
     expect(foundWords()).toEqual(['ACTION']);
   });
 
-  it('known gap (#167): treats a slot filled by an unrecoverable masked guess as never filled', async () => {
-    // APPROVED (#167): the slot COUNTS as filled, so the level counts as a clear
-    //                  and the word is not reported as missed — but the board is
-    //                  NOT saved, because one of its words is not known. The
-    //                  maintainer deliberately decoupled those two outcomes.
-    // TODAY:           the slot is treated as never filled, losing the clear AND
-    //                  reporting the word as missed.
-    //
-    // The assertions below pin TODAY. Invert them when #167 lands — and note the
-    // board-capture half must stay blocked, which is the part easiest to miss.
-    // See `specs/game-flow.md § Approved, not yet implemented`.
+  it('#167: an unrecoverable masked guess still counts as a clear, but keeps the board unsaved', async () => {
+    // ✅ Confirmed (#160 review), fixed by #167: the slot COUNTS as filled, so
+    // the level counts as a clear and the word is not reported as missed —
+    // but the board is NOT saved, because one of its words is not known. The
+    // maintainer deliberately decoupled those two outcomes; see
+    // `specs/game-flow.md § Masked guesses`.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => { });
     spectator.isSoundsEnabled = true;
     await startTrilbyLevel([6, 5]);
@@ -1050,11 +1051,16 @@ describe('specs/game-flow.md § Masked guesses', () => {
 
     await playWosEvent(levelResults(2));
 
-    // Both slots were genuinely filled by players, but the level is not a clear
-    // and no board is captured (no POST handler is registered, so an attempted
-    // capture would fail this test).
-    expect(soundsPlayed).not.toContain('/assets/clear.mp3');
-    expect(spectator.currentLevelSlots[1].user).toBeUndefined();
+    // Both slots were genuinely filled by players, so the level is a clear —
+    // even though the second slot's real word was never recovered.
+    expect(soundsPlayed).toContain('/assets/clear.mp3');
+    expect(spectator.currentLevelSlots[1].user).toBe('biocow');
+    // The unrecoverable slot stays masked rather than guessing at a word, so
+    // it can never be mistaken for the real answer.
+    expect(spectator.currentLevelSlots[1].word).toBe('?????');
+    // No board is captured: `saveBoard` refuses any '?'-bearing slot, and no
+    // POST handler is registered here, so an attempted capture would fail
+    // this test regardless of that guard.
     warn.mockRestore();
   });
 

--- a/tests/unit/wos-plus-main.test.ts
+++ b/tests/unit/wos-plus-main.test.ts
@@ -1815,6 +1815,24 @@ describe('GameSpectator class', () => {
       warnSpy.mockRestore();
     });
 
+    it('#167: records an unrecoverable hidden guess as a masked, user-attributed slot rather than an empty one', () => {
+      // Approved (#167): the slot still counts as filled — so the level can
+      // be a clear and the word is not reported as missed — but the word
+      // itself stays unknown. Recording it masked (rather than resolving to
+      // some guessed word) is what keeps it out of the boards table:
+      // `saveBoard` refuses any slot whose `letters`/`word` still contain '?'.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+      (spectator as any).updateGameState('testuser', ['?', '?', '?', '?'], 0, false);
+
+      expect(spectator.currentLevelSlots[0].user).toBe('testuser');
+      expect(spectator.currentLevelSlots[0].word).toBe('????');
+      expect(spectator.currentLevelSlots[0].letters).toEqual(['?', '?', '?', '?']);
+      // Still not added to the found-words log: the word itself is unknown.
+      expect(spectator.currentLevelCorrectWords).toEqual([]);
+      warnSpy.mockRestore();
+    });
+
     it('should capture a non-hidden guess directly from letters without any chat message (issue #96)', () => {
       // The WoS event carries the full word for non-hidden levels, so a correct
       // guess must be captured even when no Twitch chat message is available


### PR DESCRIPTION
## What changed

Implements the last open item from the #160-review behaviour backlog: [#167](https://github.com/clarkio/wos-plus/issues/167). Approved rule (see the issue, resolving spec question G2): a masked correct-guess event WoS+ cannot match to any chat message must still **count as filled** for clear detection and missed-word purposes, but its word is unknown, so the **board must not be saved or updated**. The two outcomes are deliberately decoupled.

`updateGameState` (`src/scripts/wos-plus-main.ts`) previously dropped an unresolved masked guess entirely (`return` with no slot update), which lost the clear *and* reported the word as missed. It now records the slot via `updateCurrentLevelSlots` with masked (`'?'`-filled) `letters`/`word` instead of dropping it. That one change gets both approved outcomes for free, because of how the surrounding code already keys off `slot.user`:

- **Clear detection** — `currentLevelSlots.every(slot => slot.user)` now sees the slot as filled.
- **Missed-word exclusion** — `findMissingWordsFromBoard`'s `!currentSlot.user` check now excludes it, and the level-clear branch skips `logMissingWords()` entirely once the level is a clear.
- **Board-save blocking** — no new code needed: `saveBoard` (`db-service.ts`) already refuses any slot whose `letters`/`word` contain `'?'`, so the masked slot keeps the whole board out of the archive.

Two other acceptance tests incidentally asserted the old drop-it behaviour (`slot.user` staying `undefined`) without being marked as the tracked `known gap (#167)` — they were updated in this PR since they encode the same pre-fix behaviour.

Draft PR #144 ("Record unrecoverable hidden mobile guesses as solved, not missed") was the open PR #167 asked to be checked/reconciled against this rule. Its `saveBoard`-guard approach was the right shape, but the branch was opened against `main` from July 18 and never rebased, so — mirroring how stale draft PR #142 was handled for #165 — it was closed as superseded rather than reconciled, with an explanatory comment. Its broader mobile-guess scope (issue #143) was not re-implemented here; only the #167 slice was in scope.

`AGENTIC-TESTING-PLAN.md`, `CLAUDE.md` § 4, `specs/game-flow.md`, and `specs/README.md` are updated to reflect this: all thirteen issues from the #160 review are now closed.

## Verification

- [x] Spec in `specs/` added or updated — `specs/game-flow.md` § Masked guesses, "no matching chat message" scenario moved from ⚠️ Approved-not-yet-implemented to ✅ Confirmed
- [x] Tests written or updated *before or with* the implementation
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally
- [x] No existing test weakened, skipped, or deleted — the two incidentally-affected tests were inverted to match the new approved behaviour, not deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

- 692 tests passing (was 691), 3 `it.todo` unchanged. Coverage: 91.41% statements / 87.77% branches / 88.94% functions / 92.08% lines — all above the enforced floors.
- No ESLint suppressions added.
- PR #144 was closed as superseded; see the comment on that PR for the reasoning.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RuAywj8pWQpmrahyitFJER)_