### PR TITLE
Add security & supply-chain CI gates (#153)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# CodeQL static analysis (SAST). Part of AGENTIC-TESTING-PLAN.md Phase 7 (#153).
+#
+# Job is named `analyze` on purpose — docs/BRANCH-PROTECTION.md's required-checks
+# table matches on job name, and that doc already reserves `analyze` for this
+# workflow. Keep the two in sync if this is ever renamed.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  schedule:
+    # Weekly full scan, independent of PR activity.
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript' ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+# Flags known-vulnerable and newly-introduced dependencies on a PR diff. Part
+# of AGENTIC-TESTING-PLAN.md Phase 7 (#153) — the primary mechanical defense
+# against a hallucinated or malicious package entering via an agent PR (it
+# cannot tell you a plausible-looking name is the wrong one; that stays a
+# human review step, see docs/BRANCH-PROTECTION.md § Dependency policy).
+#
+# Job is named `dependency-review` on purpose — docs/BRANCH-PROTECTION.md's
+# required-checks table matches on job name and already reserves this name.
+
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,61 @@
+# Secret scanning (defense in depth) and dependency audit. Part of
+# AGENTIC-TESTING-PLAN.md Phase 7 (#153).
+#
+# Neither job here is listed as a required check in docs/BRANCH-PROTECTION.md:
+# gitleaks backstops GitHub's native secret scanning + push protection (a
+# maintainer-only repo setting, documented there — this workflow runs *after*
+# a push already happened, so it is defense in depth, not the primary gate),
+# and pnpm-audit starts non-blocking (see the job below for why).
+
+name: Security
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
+  pnpm-audit:
+    name: pnpm-audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # Non-blocking for now: as of the #153 audit, `pnpm audit --prod` reports
+      # 7 high / 7 moderate / 0 critical, all in transitive build/runtime
+      # tooling (astro/cloudflare/sentry toolchains, socket.io-client), none
+      # with a patched version available yet within this repo's pinned major
+      # versions. Report the output here, triage against upstream fixes, and
+      # flip this to blocking (drop continue-on-error, or gate on severity)
+      # once the current findings are resolved or explicitly accepted.
+      - name: Audit production dependencies
+        run: pnpm audit --prod
+        continue-on-error: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+# gitleaks config for WoS+. Extends the default ruleset; adds an allowlist for
+# the fake Supabase credentials used by the acceptance-test harness so CI
+# doesn't choke on test fixtures. See AGENTIC-TESTING-PLAN.md Phase 7 (#153).
+#
+# This is an allowlist, not a weakened rule: it names the exact known-fake
+# strings, so a real credential landing anywhere else — including in these
+# same files — still trips the scan.
+
+title = "WoS+ gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-fake Supabase credentials used only in test fixtures, and Twitch's own public web Client-Id"
+regexes = [
+  '''stub-key-not-a-real-credential''',
+  '''unused-by-a-liveness-check''',
+  # Twitch's own public web client id (kimne78kx3ncx6brgo4mv6wki5h1ko), used by
+  # twitch.tv's own frontend and widely published/reused by third-party tools
+  # for unauthenticated, read-only gql.twitch.tv lookups. Not a secret — see
+  # the comment above its declaration in src/scripts/twitch-channel.ts.
+  '''kimne78kx3ncx6brgo4mv6wki5h1ko''',
+]
+paths = [
+  '''tests/stubs/cloudflare-workers\.ts''',
+  '''tests/acceptance/health\.acceptance\.test\.ts''',
+  '''src/scripts/twitch-channel\.ts''',
+]

--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -25,7 +25,7 @@ describe intent, not status. This section is the status.
 | 4 — Property-based tests (fast-check) | [#150](https://github.com/clarkio/wos-plus/issues/150) | ✅ done | PR #159 |
 | 5 — Mutation testing + change-risk | [#154](https://github.com/clarkio/wos-plus/issues/154) | ⬜ not started | — |
 | 6 — Thin Playwright E2E | [#152](https://github.com/clarkio/wos-plus/issues/152) | ⬜ not started | — |
-| 7 — Security & supply-chain gates | [#153](https://github.com/clarkio/wos-plus/issues/153) | ⬜ not started | — |
+| 7 — Security & supply-chain gates | [#153](https://github.com/clarkio/wos-plus/issues/153) | ✅ done | this PR |
 | 8 — Branch protection & agent contract | [#156](https://github.com/clarkio/wos-plus/issues/156) | ✅ done | PR #159 + maintainer enabled protection on `main` |
 
 Epic tracker: [#157](https://github.com/clarkio/wos-plus/issues/157).
@@ -298,6 +298,48 @@ With all thirteen #160-review issues closed, the next open items are #153
 (mutation testing, needs maintainer sign-off for the StrykerJS dependency per
 `CLAUDE.md` §2.3). #152 (Playwright E2E) stays last or never, per the
 existing sandbox caveat below.
+
+**#153 is done.** Four workflow files, no source/test/build-config changes,
+per its scoped acceptance criteria:
+
+- `.github/workflows/codeql.yml` — CodeQL, `javascript-typescript`, job named
+  `analyze` (matches `docs/BRANCH-PROTECTION.md`'s required-checks table), on
+  PRs, pushes to `main`, and a weekly schedule.
+- `.github/workflows/dependency-review.yml` — `actions/dependency-review-action`
+  on PRs, job named `dependency-review`, failing on high-severity advisories.
+  This is the mechanical defense against a hallucinated or malicious package
+  entering via an agent PR.
+- `.github/workflows/security.yml` — two non-required jobs, defense in depth
+  rather than primary gates: `gitleaks` (blocking; scans full git history on
+  every PR/push) and `pnpm-audit` (`pnpm audit --prod`, currently
+  `continue-on-error: true`).
+- `.gitleaks.toml` — an allowlist, not a weakened rule. A first local run
+  (`gitleaks git --config .gitleaks.toml -v .`) found one flagged string:
+  `TWITCH_PUBLIC_CLIENT_ID` in `src/scripts/twitch-channel.ts`
+  (`kimne78kx3ncx6brgo4mv6wki5h1ko`), which is Twitch's own published public
+  web `Client-Id` for unauthenticated `gql.twitch.tv` lookups — reused openly
+  by third-party Twitch tools, not a secret. That string plus the acceptance
+  harness's known-fake Supabase credentials are allowlisted by exact value and
+  path; nothing else is excluded, so a real credential anywhere else — even in
+  those same files — still trips the scan. After the allowlist, the scan is
+  clean (`no leaks found`, 97 commits).
+- `pnpm audit --prod`, run locally for this PR: **7 high, 7 moderate, 0
+  critical**, all transitive (astro/cloudflare/sentry toolchains,
+  socket.io-client), none with a patched version available yet within this
+  repo's pinned major versions. Left non-blocking per the issue, with the
+  reasoning recorded in the workflow file and in
+  `docs/BRANCH-PROTECTION.md`.
+- `docs/BRANCH-PROTECTION.md` updated: the required-checks table now marks
+  `analyze` and `dependency-review` available (job names matched what the
+  table already reserved for them); a new paragraph explains why `gitleaks`
+  and `pnpm-audit` are deliberately *not* required checks; the GitHub-native
+  secret scanning / push protection section is now explicitly marked as
+  needing maintainer/repo-admin action, which was implicit before.
+
+No CodeQL or dependency-review run can be verified locally — both only run on
+GitHub — so their YAML was validated with a parser (`python3 -c
+"import yaml; yaml.safe_load(...)"`) rather than eyeballed, per the issue's
+own instruction.
 
 ### Where the rest of the state lives
 

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -34,10 +34,13 @@ exists today; tick the others as their phases land.
 | Check | Workflow | Job | Status |
 | --- | --- | --- | --- |
 | `build` | `tests.yml` | `build` | **available now** — runs install → check → lint → acceptance → test+coverage → build |
-| `analyze` | `codeql.yml` | — | pending #153 |
-| `dependency-review` | `dependency-review.yml` | — | pending #153 |
+| `analyze` | `codeql.yml` | `analyze` | **available now**, landed with #153 — CodeQL, `javascript-typescript`, on PRs/push to `main`/weekly schedule |
+| `dependency-review` | `dependency-review.yml` | `dependency-review` | **available now**, landed with #153 — fails on high-severity advisories in a PR's dependency diff |
 | `e2e` | e2e workflow | — | pending #152 |
 | acceptance stream | `tests.yml` | `build`, step "Run acceptance tests" | **landed with #151** as a separate *step*, not a separate job — see below |
+
+`security.yml`'s two jobs (`gitleaks`, `pnpm-audit`), also landed with #153, are
+**not** on this required-checks table on purpose — see the next section.
 
 > The single `build` job currently bundles type-check, lint, tests and build.
 > That is fine for enforcement (any failure fails the job) but coarse in the
@@ -76,6 +79,9 @@ trigger stays scoped to `main`. Do not re-add the filter.
 
 ## GitHub-native security settings
 
+**This section requires maintainer/repo-admin action.** None of it can be
+turned on from a pull request.
+
 In **Settings → Code security**:
 
 - **Secret scanning** — on.
@@ -84,8 +90,22 @@ In **Settings → Code security**:
   is the Supabase keys.
 - **Dependabot alerts** — on.
 
-`gitleaks` in CI (pending #153) is defence in depth, not a replacement: it runs
-after the push has already happened.
+`gitleaks` in CI (`security.yml`, landed with #153) is defence in depth, not a
+replacement: it runs after the push has already happened, and it is
+deliberately **not** a required check (see the table above) — it exists to
+catch what push protection missed, not to gate merges on its own. Its
+allowlist (`.gitleaks.toml`) is scoped to two things: the fake Supabase
+credentials the acceptance-test harness uses, and Twitch's own public web
+`Client-Id` (`src/scripts/twitch-channel.ts`) — a widely-published,
+intentionally non-secret identifier, not a leaked credential.
+
+`pnpm audit --prod` also runs in `security.yml` (job `pnpm-audit`), currently
+**non-blocking** (`continue-on-error: true`). As of #153 it reports 7 high /
+7 moderate / 0 critical advisories, all transitive (astro/cloudflare/sentry
+toolchains, socket.io-client) with no patched version yet available within
+this repo's pinned major versions. Revisit periodically — this file makes no
+claim about *when* it becomes blocking, since that depends on upstream fixes
+landing, not on this PR.
 
 ---
 
@@ -100,9 +120,9 @@ already close most of the gap. The remaining human step:
 > package is the real, established artifact** — correct name, expected author,
 > plausible download history and repository — before approving.
 
-`actions/dependency-review-action` (pending #153) automates the
-known-vulnerability half of this. It cannot tell you that a plausible-looking
-package name is the one you actually meant.
+`actions/dependency-review-action` (`dependency-review.yml`, landed with #153)
+automates the known-vulnerability half of this. It cannot tell you that a
+plausible-looking package name is the one you actually meant.
 
 ---
 


### PR DESCRIPTION
## What changed

Implements [#153](https://github.com/clarkio/wos-plus/issues/153) — AGENTIC-TESTING-PLAN.md Phase 7 (security & supply-chain gates). Workflow files only, as scoped by the issue: no `package.json`, `vitest.config.ts`, or source file changes.

- `.github/workflows/codeql.yml` — CodeQL, `javascript-typescript`, job `analyze` (matches the name `docs/BRANCH-PROTECTION.md` already reserved), on PRs, pushes to `main`, and weekly.
- `.github/workflows/dependency-review.yml` — `actions/dependency-review-action`, job `dependency-review`, fails on high-severity advisories in a PR's dependency diff. Primary mechanical defense against a hallucinated/malicious package entering via an agent PR.
- `.github/workflows/security.yml` — two jobs, deliberately **not** required checks (defense in depth, not primary gates): `gitleaks` (blocking, full history scan) and `pnpm-audit` (`pnpm audit --prod`, `continue-on-error: true` for now).
- `.gitleaks.toml` — allowlist, not a weakened rule. A local run (`gitleaks git --config .gitleaks.toml -v .`) found one flagged string before the allowlist: `TWITCH_PUBLIC_CLIENT_ID` in `src/scripts/twitch-channel.ts` (`kimne78kx3ncx6brgo4mv6wki5h1ko`) — Twitch's own published public web `Client-Id` for unauthenticated `gql.twitch.tv` lookups, openly reused by third-party Twitch tools, not a secret. Allowlisted that plus the acceptance harness's known-fake Supabase credentials, by exact value and path. After the allowlist: **`no leaks found`, 97 commits scanned.**
- `docs/BRANCH-PROTECTION.md` — required-checks table updated (`analyze`, `dependency-review` now available); new explanation of why `gitleaks`/`pnpm-audit` are non-required; the GitHub-native secret-scanning/push-protection section is now explicitly marked as needing maintainer/repo-admin action.
- `AGENTIC-TESTING-PLAN.md` — Phase 7 marked done in the status table, with the full reasoning recorded in "What to do next, and why."

## `pnpm audit --prod` output (run locally for this PR)

**7 high, 7 moderate, 0 critical.** All transitive, in build/runtime tooling this repo doesn't control directly: `sharp` (via astro/cloudflare/miniflare/wrangler), `brace-expansion` (via `@sentry/astro`'s bundler plugins, two separate advisories), `socket.io-parser` (via `socket.io-client`), `undici` (via astro/cloudflare/wrangler/miniflare). None has a patched version available yet within this repo's pinned major versions, so the `pnpm-audit` job stays non-blocking (`continue-on-error: true`) per the issue's instruction, with the reasoning recorded in the workflow file itself.

## Verification

- [ ] Spec in `specs/` added or updated (behavior changes only — see note below): **N/A**, no behavior change
- [ ] Tests written or updated *before or with* the implementation: **N/A**, no source/test change (issue scope excludes them)
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally (unaffected — no source touched; ran `pnpm run lint` to confirm)
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none** — all four workflow files use GitHub Actions (`github/codeql-action`, `actions/dependency-review-action`, `gitleaks/gitleaks-action`), not npm packages
- [x] Code authored with AI assistance: **yes**

All workflow YAML was validated with a parser (`python3 -c "import yaml; yaml.safe_load(...)"`) rather than eyeballed, and `.gitleaks.toml` with `tomllib`, per the issue's own instruction that CodeQL/dependency-review can't be exercised locally.

## Notes for the reviewer

- The one gitleaks finding before the allowlist (Twitch's public web `Client-Id`) is a known non-secret, not a real credential — see the reasoning above and the comment in `.gitleaks.toml`. No real secret was found or committed.
- `pnpm-audit` and `gitleaks` are intentionally left off `docs/BRANCH-PROTECTION.md`'s required-checks table — they're defense in depth per the issue's own framing (GitHub-native secret scanning + push protection, and the human dependency-verification step, are the primary gates; both are maintainer/repo-admin settings documented in `docs/BRANCH-PROTECTION.md` and not changeable from a PR).
- Next open items per `AGENTIC-TESTING-PLAN.md`: #154 (mutation testing, needs maintainer sign-off for the StrykerJS dependency), #152 (Playwright E2E, last or never per the sandbox caveat).

Claude-Session: https://claude.ai/code/session_01HbqvKF1v2nMPrP19UnTAow

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbqvKF1v2nMPrP19UnTAow)_