### PR TITLE
Add thin Playwright E2E smoke layer (Phase 6 / #152)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,17 @@ on:
   # stacked PR targeting another feature branch must still get a real run.
   pull_request:
 
+# Least-privilege GITHUB_TOKEN, matching codeql.yml and security.yml: this
+# job only checks out code, builds, and runs tests — it never needs to write
+# to the repo or call any other API.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -27,8 +35,9 @@ jobs:
       # Builds and starts `wrangler dev` itself via playwright.config.ts's
       # `webServer`. No Supabase secrets are provisioned here, so /player and
       # /streamer's dictionary/channel-stats fetches are expected to fail
-      # gracefully — tests/e2e/e2e-harness.ts filters that known gap out of
-      # the console-error assertions rather than treating it as a regression.
+      # gracefully — tests/e2e/e2e-harness.ts's collectUnexpectedFailures
+      # checks for that known gap by URL rather than treating it as a
+      # regression.
       - name: Run E2E smoke suite
         run: pnpm run test:e2e
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+name: E2E
+
+on:
+  push:
+    branches: [ "main" ]
+  # No branches: filter on pull_request, same reasoning as tests.yml: a
+  # stacked PR targeting another feature branch must still get a real run.
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright's Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      # Builds and starts `wrangler dev` itself via playwright.config.ts's
+      # `webServer`. No Supabase secrets are provisioned here, so /player and
+      # /streamer's dictionary/channel-stats fetches are expected to fail
+      # gracefully — tests/e2e/e2e-harness.ts filters that known gap out of
+      # the console-error assertions rather than treating it as a regression.
+      - name: Run E2E smoke suite
+        run: pnpm run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,9 @@ vite.config.ts.timestamp-*
 # of committing either.
 reports/
 .stryker-tmp/
+
+# Playwright E2E (AGENTIC-TESTING-PLAN.md #152): generated report and
+# per-run artifacts (traces, screenshots), not source. CI uploads the report
+# as a workflow artifact on failure instead of committing it.
+playwright-report/
+test-results/

--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -84,13 +84,21 @@ added, scoped to a thin smoke layer per the issue's own scope:
   Supabase secrets, so `/player` and `/streamer`'s in-page word-dictionary and
   channel-stats fetches fail there the same way they would locally without
   `.dev.vars` — already caught and logged by the routes rather than thrown, so
-  the page still renders. `e2e-harness.ts`'s console-error filter names this
-  gap explicitly, scoped to the specific request URLs it expects to fail
-  (`/api/words`, `/api/channel-stats/*`, plus the blocked hosts above) rather
-  than by generic message text — Chrome's own resource-failure console
-  messages carry no URL, so the filter tracks `requestfailed`/`response`
-  events by URL and only forgives that many generic messages, leaving an
-  unrelated failure visible. Wiring real or sandboxed credentials into the
+  the page still renders. `e2e-harness.ts`'s `collectUnexpectedFailures` names
+  this gap explicitly via a dedicated, URL-attributed check
+  (`unexpectedRequestFailures`, built from `requestfailed`/`response` events
+  against the known-expected list: `/api/words`, `/api/channel-stats/*`, plus
+  the blocked hosts above) rather than trying to pattern-match generic
+  console text, which carries no URL. An earlier version tracked expected
+  failures as a single page-global counter decremented against generic
+  console messages; review on PR #194 caught that console and network events
+  aren't guaranteed to arrive in a correlated order, so an unrelated failure
+  could silently consume budget left over from an earlier expected one. The
+  fix judges the two independently instead: generic resource-failure console
+  text is dropped outright (unattributable), and the URL-based network check
+  is what actually catches an unrelated failure, regardless of what else
+  failed first — covered by a regression test in `tests/e2e/smoke.spec.ts`.
+  Wiring real or sandboxed credentials into the
   job is future work, out of scope for a suite whose actual target is
   `prerender = false` / `locals.runtime.env` misconfiguration and
   page-load/dialog behaviour.

--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -24,7 +24,7 @@ describe intent, not status. This section is the status.
 | 3 — Acceptance-test stream (ATDD) | [#151](https://github.com/clarkio/wos-plus/issues/151) | ✅ done | PR #160 |
 | 4 — Property-based tests (fast-check) | [#150](https://github.com/clarkio/wos-plus/issues/150) | ✅ done | PR #159 |
 | 5 — Mutation testing + change-risk | [#154](https://github.com/clarkio/wos-plus/issues/154) | ✅ done | this PR |
-| 6 — Thin Playwright E2E | [#152](https://github.com/clarkio/wos-plus/issues/152) | ⬜ not started | — |
+| 6 — Thin Playwright E2E | [#152](https://github.com/clarkio/wos-plus/issues/152) | ✅ done | this PR |
 | 7 — Security & supply-chain gates | [#153](https://github.com/clarkio/wos-plus/issues/153) | ✅ done | this PR |
 | 8 — Branch protection & agent contract | [#156](https://github.com/clarkio/wos-plus/issues/156) | ✅ done | PR #159 + maintainer enabled protection on `main` |
 
@@ -50,12 +50,48 @@ verified by temporarily raising a threshold above measured reality and watching
 the run fail, then reverting.
 
 The **behaviour issues** below (all thirteen from the #160 review) are now done,
-and so are #153 and #154. The only phase left is **#152** (thin Playwright
-E2E), last or never — `wrangler dev` may not run in a sandbox at all.
+and so are #153, #154, and #152. **Every phase in the table above is now done**
+— #157 (the epic) is the only thing left open, and only as a tracking issue.
 
-**#152 needs maintainer sign-off before starting**, per `CLAUDE.md` §5: it adds
-Playwright as a new dependency, an architecture-tier change. (#154's own
-sign-off, for adding StrykerJS, was obtained and is recorded below.)
+**#152 is done**, with explicit maintainer sign-off obtained before adding the
+new dependency, per `CLAUDE.md` §5 (architecture-tier — same policy #154's
+StrykerJS addition went through). `@playwright/test` 1.62.1 (exact-pinned) was
+added, scoped to a thin smoke layer per the issue's own scope:
+
+- `wrangler dev` **does run in this sandbox** — the open question the plan
+  flagged going in. `curl http://127.0.0.1:8788/` and `/api/health` both
+  answer 200 against a real `astro build` + `wrangler dev`. Two environment
+  quirks needed working around, not signs the approach doesn't work: `wrangler
+  dev` only binds IPv4, so Chromium resolving `localhost` to `::1` first hangs
+  — `playwright.config.ts` uses `127.0.0.1` explicitly; and Chromium refuses
+  to start its own sandbox as root (this sandbox's user), worked around with
+  `--no-sandbox` in `launchOptions.args`, gated on `PLAYWRIGHT_CHROMIUM_PATH`
+  being set so a normal non-root CI runner is unaffected.
+- **Scope**: `tests/e2e/smoke.spec.ts` covers `/`, `/player`, `/streamer`
+  loading without unexpected console errors; `/api/health` returning 200
+  through the real Workers runtime; and the settings dialog opening when
+  required query params are missing (both `/player` and `/streamer`).
+  `tests/e2e/settings-dialog.spec.ts` covers the settings dialog's URL-param
+  round trip. WoS WebSocket and Twitch chat connections stay out of scope, per
+  the issue — `tests/e2e/e2e-harness.ts`'s `blockExternalNetwork` aborts
+  Google Fonts and Twitch's GQL lookup so the suite stays hermetic (same "zero
+  real network" convention the acceptance stream already uses), and the
+  URL-round-trip test doesn't assert on console output at all, since Save
+  fires a real (out-of-scope) connection attempt to the live WoS mirror socket.
+- **A real, known gap, not swept under the rug**: `e2e.yml` provisions no
+  Supabase secrets, so `/player` and `/streamer`'s in-page word-dictionary and
+  channel-stats fetches fail there the same way they would locally without
+  `.dev.vars` — already caught and logged by the routes rather than thrown, so
+  the page still renders. `e2e-harness.ts`'s console-error filter names this
+  gap explicitly (by message shape, since Chrome's own resource-failure
+  console messages carry no URL) rather than silently absorbing it; wiring
+  real or sandboxed credentials into the job is future work, out of scope for
+  a suite whose actual target is `prerender = false` /
+  `locals.runtime.env` misconfiguration and page-load/dialog behaviour.
+- `docs/BRANCH-PROTECTION.md`'s `e2e` row is now marked available (job `e2e`
+  in `.github/workflows/e2e.yml`), with the Supabase-secrets gap noted there
+  too; it is not yet ticked as a required check — that's a maintainer action,
+  same as the other rows in that table.
 
 ### The behaviour backlog from the #160 review
 
@@ -391,11 +427,10 @@ excluding `wos-plus-main.ts`.
   touches means that PR's tests don't actually constrain the new code — add
   an assertion, never suppress the mutant.
 
-With #154 done, every phase in the table above is closed except **#152**
-(thin Playwright E2E), which also needs maintainer sign-off per `CLAUDE.md`
-§5 and stays last-or-never per the existing sandbox caveat: `wrangler dev`
-may not run in this environment at all, so the day it's picked up should
-start by testing that assumption before writing any spec.
+**With #152 done, every phase in the table above is closed.** #157 (the epic)
+is the only tracking issue still open. `wrangler dev` turned out to run fine
+in the sandbox this landed in — see § What to do next, and why for how that
+was verified and what #152's implementation covers.
 
 ### Where the rest of the state lives
 

--- a/AGENTIC-TESTING-PLAN.md
+++ b/AGENTIC-TESTING-PLAN.md
@@ -72,22 +72,28 @@ added, scoped to a thin smoke layer per the issue's own scope:
   through the real Workers runtime; and the settings dialog opening when
   required query params are missing (both `/player` and `/streamer`).
   `tests/e2e/settings-dialog.spec.ts` covers the settings dialog's URL-param
-  round trip. WoS WebSocket and Twitch chat connections stay out of scope, per
-  the issue — `tests/e2e/e2e-harness.ts`'s `blockExternalNetwork` aborts
-  Google Fonts and Twitch's GQL lookup so the suite stays hermetic (same "zero
-  real network" convention the acceptance stream already uses), and the
-  URL-round-trip test doesn't assert on console output at all, since Save
-  fires a real (out-of-scope) connection attempt to the live WoS mirror socket.
+  round trip. Twitch chat connections stay out of scope, per the issue —
+  `tests/e2e/e2e-harness.ts`'s `blockExternalNetwork` aborts Google Fonts and
+  Twitch's GQL lookup over HTTP, and mocks the WoS mirror WebSocket
+  (`wos2.gartic.es`, opened by Save via socket.io's `transports: ['websocket']`
+  — `page.route` can't intercept that, only `page.routeWebSocket` can) so the
+  suite stays hermetic (same "zero real network" convention the acceptance
+  stream already uses) even though the URL-round-trip test doesn't itself
+  assert on console output.
 - **A real, known gap, not swept under the rug**: `e2e.yml` provisions no
   Supabase secrets, so `/player` and `/streamer`'s in-page word-dictionary and
   channel-stats fetches fail there the same way they would locally without
   `.dev.vars` — already caught and logged by the routes rather than thrown, so
   the page still renders. `e2e-harness.ts`'s console-error filter names this
-  gap explicitly (by message shape, since Chrome's own resource-failure
-  console messages carry no URL) rather than silently absorbing it; wiring
-  real or sandboxed credentials into the job is future work, out of scope for
-  a suite whose actual target is `prerender = false` /
-  `locals.runtime.env` misconfiguration and page-load/dialog behaviour.
+  gap explicitly, scoped to the specific request URLs it expects to fail
+  (`/api/words`, `/api/channel-stats/*`, plus the blocked hosts above) rather
+  than by generic message text — Chrome's own resource-failure console
+  messages carry no URL, so the filter tracks `requestfailed`/`response`
+  events by URL and only forgives that many generic messages, leaving an
+  unrelated failure visible. Wiring real or sandboxed credentials into the
+  job is future work, out of scope for a suite whose actual target is
+  `prerender = false` / `locals.runtime.env` misconfiguration and
+  page-load/dialog behaviour.
 - `docs/BRANCH-PROTECTION.md`'s `e2e` row is now marked available (job `e2e`
   in `.github/workflows/e2e.yml`), with the Supabase-secrets gap noted there
   too; it is not yet ticked as a required check — that's a maintainer action,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The shape you need to know before touching code:
 | API routes | `src/pages/api/**` | Must `export const prerender = false`; env via `locals.runtime.env` |
 | Shared helpers | `src/lib/**` | e.g. `cors.ts`, `board-utils.ts`, `launch-menu.ts` |
 | Tests | `tests/unit/`, `tests/acceptance/`, `tests/property/` | Vitest 4 + happy-dom; setup in `tests/setup.ts`. Two streams — see §7 |
+| E2E smoke | `tests/e2e/` | Playwright, against a real `wrangler dev` runtime. Separate from Vitest — see §9 |
 | Behavioural contract | `specs/` | Human-owned. Acceptance tests cite it; open questions indexed in [specs/README.md](specs/README.md) |
 | **Where the quality plan stands** | [AGENTIC-TESTING-PLAN.md § Where this stands](AGENTIC-TESTING-PLAN.md) | Phase-by-phase status, what to do next, and the 13-issue behaviour backlog. **Start here if picking the work up cold.** |
 
@@ -348,3 +349,56 @@ notices — AGENTIC-TESTING-PLAN.md Phase 5 / issue #154.
   the source of truth for the decomposition work and the next ceiling number.
 - `reports/` and `.stryker-tmp/` are generated and gitignored; CI publishes
   the HTML report as an artifact instead of committing it.
+
+---
+
+## 9. Thin E2E smoke layer (`tests/e2e/`, `playwright.config.ts`)
+
+The last layer of the Testing Trophy (AGENTIC-TESTING-PLAN.md Phase 6 /
+issue #152): a handful of Playwright tests against a real production build
+running under `wrangler dev` — the only layer that catches `prerender =
+false` / `locals.runtime.env` misconfigurations, since unit and acceptance
+tests invoke route handlers directly and never touch an actual Workers
+runtime.
+
+- **`pnpm run test:e2e`** runs the suite (`playwright test`). It is **not**
+  part of the §2.4 local gate — like mutation testing, it's a separate,
+  slower layer with its own CI job (`.github/workflows/e2e.yml`, job `e2e`),
+  not bundled into `build`.
+- **Deliberately narrow, per the plan's "thin E2E" framing**: page loads for
+  `/`, `/player`, `/streamer` without unexpected console errors; `/api/health`
+  returning 200 through the real Workers runtime; the settings dialog opening
+  when required query params are missing; and the dialog's Save flow
+  round-tripping values into URL params. WoS WebSocket and Twitch chat
+  connections are explicitly **out of scope** — that protocol handling is
+  already covered deterministically by the fixture-driven worker tests
+  (`tests/unit/wos-worker.test.ts`, `tests/unit/twitch-chat-worker.test.ts`).
+- **Hermetic by the same convention as the acceptance stream** (§7): zero
+  reliance on real third-party network reachability. `tests/e2e/e2e-harness.ts`
+  aborts Google Fonts and Twitch's GQL lookup (`blockExternalNetwork`) rather
+  than depending on whether those hosts happen to be reachable in a given CI
+  or sandbox network policy.
+- **A named, not hidden, gap**: `e2e.yml` provisions no Supabase credentials,
+  so `/player`/`/streamer`'s in-page word-dictionary and channel-stats
+  fetches fail the same way they would locally without `.dev.vars` — the
+  routes already catch and log rather than throw, so pages still render.
+  `e2e-harness.ts`'s console-error filter names this exact known gap (by
+  message shape — Chrome's own resource-failure console messages carry no
+  URL) instead of silently swallowing all console errors. Wiring real or
+  sandboxed Supabase credentials into the CI job is future work; it isn't
+  required for this suite to be a meaningful gate, since its actual target is
+  Workers-runtime wiring and page/dialog behavior, not Supabase-backed data.
+- **Browser**: `@playwright/test` 1.62.1, exact-pinned. `playwright.config.ts`
+  uses `127.0.0.1` rather than `localhost` for `baseURL` and the `webServer`
+  health-check URL — `wrangler dev` only binds IPv4, and some sandboxes
+  resolve `localhost` to `::1` first, which hangs. Locally, set
+  `PLAYWRIGHT_CHROMIUM_PATH` to reuse a preinstalled Chromium instead of
+  downloading one (this also gates `--no-sandbox`, needed only when Chromium
+  runs as root); CI installs its own via
+  `pnpm exec playwright install --with-deps chromium` and leaves that env var
+  unset.
+- `playwright-report/` and `test-results/` are generated and gitignored; CI
+  uploads the HTML report as a workflow artifact on failure instead of
+  committing it.
+- `docs/BRANCH-PROTECTION.md`'s `e2e` row is available but not yet a required
+  status check — same maintainer action as the other rows in that table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,14 +386,21 @@ runtime.
   so `/player`/`/streamer`'s in-page word-dictionary and channel-stats
   fetches fail the same way they would locally without `.dev.vars` — the
   routes already catch and log rather than throw, so pages still render.
-  `e2e-harness.ts`'s console-error filter names this exact known gap, scoped
-  by URL rather than by message text: Chrome's own resource-failure console
-  messages are generic and carry no URL, so the harness instead watches the
-  network layer (`requestfailed` / `response`) to learn which specific
-  request URLs (the blocked hosts above, `/api/words`, `/api/channel-stats/*`)
-  are expected to fail, and only forgives that many generic console
-  messages — an unrelated failing script or route still surfaces as an
-  unexpected error. Wiring real or sandboxed Supabase credentials into the CI
+  `e2e-harness.ts`'s `collectUnexpectedFailures` names this exact known gap,
+  scoped by URL rather than by message text: Chrome's own resource-failure
+  console messages are generic and carry no URL, and console events aren't
+  guaranteed to arrive in a correlated order with the network events that do
+  carry one, so the two are judged independently rather than one "forgiving"
+  a count against the other — a page-global counter was tried and rejected in
+  review (PR #194) for exactly that ordering risk (an unrelated failure could
+  consume budget left over from an earlier expected one and go unreported).
+  Generic resource-failure console text is dropped outright since it can't be
+  attributed to a URL; `unexpectedRequestFailures` is the real check, built
+  from `requestfailed`/`response` events (which do carry a URL) against the
+  known-expected list (the blocked hosts above, `/api/words`,
+  `/api/channel-stats/*`) — an unrelated failing request still surfaces there
+  regardless of what else failed first. Wiring real or sandboxed Supabase
+  credentials into the CI
   job is future work; it isn't required for this suite to be a meaningful
   gate, since its actual target is Workers-runtime wiring and page/dialog
   behavior, not Supabase-backed data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,19 +375,28 @@ runtime.
   (`tests/unit/wos-worker.test.ts`, `tests/unit/twitch-chat-worker.test.ts`).
 - **Hermetic by the same convention as the acceptance stream** (§7): zero
   reliance on real third-party network reachability. `tests/e2e/e2e-harness.ts`
-  aborts Google Fonts and Twitch's GQL lookup (`blockExternalNetwork`) rather
-  than depending on whether those hosts happen to be reachable in a given CI
-  or sandbox network policy.
+  aborts Google Fonts and Twitch's GQL lookup over HTTP (`blockExternalNetwork`),
+  and separately mocks the WoS mirror socket (`wos2.gartic.es`) via
+  `page.routeWebSocket` — the settings dialog's Save flow opens that
+  connection as a raw WebSocket (socket.io with `transports: ['websocket']`,
+  no HTTP fallback), which `page.route` cannot intercept. Neither depends on
+  whether those hosts happen to be reachable in a given CI or sandbox network
+  policy.
 - **A named, not hidden, gap**: `e2e.yml` provisions no Supabase credentials,
   so `/player`/`/streamer`'s in-page word-dictionary and channel-stats
   fetches fail the same way they would locally without `.dev.vars` — the
   routes already catch and log rather than throw, so pages still render.
-  `e2e-harness.ts`'s console-error filter names this exact known gap (by
-  message shape — Chrome's own resource-failure console messages carry no
-  URL) instead of silently swallowing all console errors. Wiring real or
-  sandboxed Supabase credentials into the CI job is future work; it isn't
-  required for this suite to be a meaningful gate, since its actual target is
-  Workers-runtime wiring and page/dialog behavior, not Supabase-backed data.
+  `e2e-harness.ts`'s console-error filter names this exact known gap, scoped
+  by URL rather than by message text: Chrome's own resource-failure console
+  messages are generic and carry no URL, so the harness instead watches the
+  network layer (`requestfailed` / `response`) to learn which specific
+  request URLs (the blocked hosts above, `/api/words`, `/api/channel-stats/*`)
+  are expected to fail, and only forgives that many generic console
+  messages — an unrelated failing script or route still surfaces as an
+  unexpected error. Wiring real or sandboxed Supabase credentials into the CI
+  job is future work; it isn't required for this suite to be a meaningful
+  gate, since its actual target is Workers-runtime wiring and page/dialog
+  behavior, not Supabase-backed data.
 - **Browser**: `@playwright/test` 1.62.1, exact-pinned. `playwright.config.ts`
   uses `127.0.0.1` rather than `localhost` for `baseURL` and the `webServer`
   health-check URL — `wrangler dev` only binds IPv4, and some sandboxes

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -52,11 +52,11 @@ to act on (`CLAUDE.md` § 8), not to block merges yet.
 in-page word-dictionary and channel-stats fetches are therefore expected to
 fail there, the same as they would locally without `.dev.vars` — the routes
 already catch and log that rather than throwing, so the pages still render,
-and `tests/e2e/e2e-harness.ts` filters that specific known gap out of its
-console-error assertions by matching the exact failing request URLs
-(`/api/words`, `/api/channel-stats/*`) rather than generic message text, so
-an unrelated failure elsewhere still surfaces rather than being masked.
-Wiring real (or sandboxed) Supabase credentials into the job is future work,
+and `tests/e2e/e2e-harness.ts`'s `collectUnexpectedFailures` checks for that
+specific known gap by the exact failing request URLs (`/api/words`,
+`/api/channel-stats/*`), independently of the generic (unattributable)
+console-error text, so an unrelated failure elsewhere still surfaces rather
+than being masked. Wiring real (or sandboxed) Supabase credentials into the job is future work,
 not required for this suite to be a meaningful gate: it targets `prerender =
 false` / `locals.runtime.env` misconfigurations and page-load/dialog
 behaviour, not Supabase-backed data.

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -36,7 +36,7 @@ exists today; tick the others as their phases land.
 | `build` | `tests.yml` | `build` | **available now** — runs install → check → lint → acceptance → test+coverage → build |
 | `analyze` | `codeql.yml` | `analyze` | **available now**, landed with #153 — CodeQL, `javascript-typescript`, on PRs/push to `main`/weekly schedule |
 | `dependency-review` | `dependency-review.yml` | `dependency-review` | **available now**, landed with #153 — fails on high-severity advisories in a PR's dependency diff |
-| `e2e` | e2e workflow | — | pending #152 |
+| `e2e` | `e2e.yml` | `e2e` | **available now**, landed with #152 — thin Playwright smoke suite against a real `wrangler dev` runtime, on PRs/push to `main` |
 | acceptance stream | `tests.yml` | `build`, step "Run acceptance tests" | **landed with #151** as a separate *step*, not a separate job — see below |
 
 `security.yml`'s two jobs (`gitleaks`, `pnpm-audit`), also landed with #153, are
@@ -47,6 +47,17 @@ landed with #154, are **also not** required checks, for the same reason as the
 `build` job's coarseness point above: a mutation run is much slower than the
 rest of the gate and exists to surface surviving mutants for a human or agent
 to act on (`CLAUDE.md` § 8), not to block merges yet.
+
+`e2e.yml` does not provision Supabase secrets. `/player` and `/streamer`'s
+in-page word-dictionary and channel-stats fetches are therefore expected to
+fail there, the same as they would locally without `.dev.vars` — the routes
+already catch and log that rather than throwing, so the pages still render,
+and `tests/e2e/e2e-harness.ts` filters that specific known gap out of its
+console-error assertions rather than masking a real regression class. Wiring
+real (or sandboxed) Supabase credentials into the job is future work, not
+required for this suite to be a meaningful gate: it targets `prerender =
+false` / `locals.runtime.env` misconfigurations and page-load/dialog
+behaviour, not Supabase-backed data.
 
 > The single `build` job currently bundles type-check, lint, tests and build.
 > That is fine for enforcement (any failure fails the job) but coarse in the

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -53,9 +53,11 @@ in-page word-dictionary and channel-stats fetches are therefore expected to
 fail there, the same as they would locally without `.dev.vars` — the routes
 already catch and log that rather than throwing, so the pages still render,
 and `tests/e2e/e2e-harness.ts` filters that specific known gap out of its
-console-error assertions rather than masking a real regression class. Wiring
-real (or sandboxed) Supabase credentials into the job is future work, not
-required for this suite to be a meaningful gate: it targets `prerender =
+console-error assertions by matching the exact failing request URLs
+(`/api/words`, `/api/channel-stats/*`) rather than generic message text, so
+an unrelated failure elsewhere still surfaces rather than being masked.
+Wiring real (or sandboxed) Supabase credentials into the job is future work,
+not required for this suite to be a meaningful gate: it targets `prerender =
 false` / `locals.runtime.env` misconfigurations and page-load/dialog
 behaviour, not Supabase-backed data.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:coverage": "vitest run --coverage",
     "test:acceptance": "vitest run tests/acceptance",
     "test:property": "vitest run tests/property",
-    "test:mutation": "stryker run"
+    "test:mutation": "stryker run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/cloudflare": "14.1.3",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@astrojs/check": "0.9.9",
     "@eslint/js": "9.39.5",
+    "@playwright/test": "1.62.1",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",
     "@types/socket.io-client": "1.4.36",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6 / issue #152).
+ *
+ * Deliberately narrow: it exercises the real Cloudflare Workers runtime via
+ * `wrangler dev` against a production build, which unit and acceptance tests
+ * structurally cannot — `prerender = false` / `locals.runtime.env`
+ * misconfigurations only show up here. Everything WoS/Twitch-live-service
+ * shaped stays out of scope; the worker/fixture tests already cover that
+ * protocol handling deterministically.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    // 127.0.0.1, not localhost: wrangler dev only binds IPv4, and some
+    // sandboxes resolve "localhost" to ::1 first, which then hangs.
+    baseURL: 'http://127.0.0.1:8788',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // This repo pins its own @playwright/test version rather than
+        // whatever revision `npx playwright install` would fetch, so point
+        // at a preinstalled Chromium (set by CI / the sandbox) instead of
+        // downloading one when available; otherwise fall back to Playwright's
+        // own managed browser.
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined,
+          // Required when Chromium runs as root (this repo's sandbox), which
+          // refuses to start its own sandbox as root; a no-op for a normal
+          // non-root CI runner user.
+          args: process.env.PLAYWRIGHT_CHROMIUM_PATH ? ['--no-sandbox'] : [],
+        },
+      },
+    },
+  ],
+
+  webServer: {
+    command: 'pnpm run build && pnpm exec wrangler dev --port 8788 --ip 127.0.0.1 --show-interactive-dev-session=false',
+    url: 'http://127.0.0.1:8788/api/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@eslint/js':
         specifier: 9.39.5
         version: 9.39.5
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@stryker-mutator/core':
         specifier: 9.6.1
         version: 9.6.1(@types/node@26.1.1)
@@ -1117,6 +1120,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2399,6 +2407,11 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3027,6 +3040,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
@@ -4892,6 +4915,10 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -6318,6 +6345,9 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6909,6 +6939,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.4:
     dependencies:

--- a/tests/e2e/e2e-harness.ts
+++ b/tests/e2e/e2e-harness.ts
@@ -51,13 +51,32 @@ export async function blockExternalNetwork(page: Page): Promise<void> {
 // provision — the same gap applies in CI until a maintainer wires up secrets
 // for the e2e job. Both routes already catch and log the failure rather than
 // throwing, so the page still renders; it's a known environment limitation,
-// not a page defect.
-const EXPECTED_500_PATHS = ['/api/words', '/api/channel-stats/'];
+// not a page defect. `/api/channel-stats/` keeps its trailing slash so it
+// only matches the route's own `/[channel]` segment, not a hypothetical
+// `/api/channel-stats-anything` route.
+const EXPECTED_EXACT_PATHS = ['/api/words'];
+const EXPECTED_PATH_PREFIXES = ['/api/channel-stats/'];
 
-const isKnownExpectedFailureUrl = (url: string): boolean =>
-  BLOCKED_HOSTS.some((host) => url.includes(host)) ||
-  url === BLOCKED_TWITCH_GQL ||
-  EXPECTED_500_PATHS.some((path) => url.includes(path));
+// Matched against the *parsed* URL's hostname/pathname rather than substrings
+// of the raw URL string — `url.includes(...)` would also match an unrelated
+// host containing a blocked one (e.g. `evil-fonts.googleapis.com.example`) or
+// an unrelated path merely containing a known one as a substring (e.g.
+// `/api/words-backup`, or a query string like `/?next=/api/words`).
+const isKnownExpectedFailureUrl = (rawUrl: string): boolean => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  return (
+    BLOCKED_HOSTS.includes(parsed.hostname) ||
+    rawUrl === BLOCKED_TWITCH_GQL ||
+    EXPECTED_EXACT_PATHS.includes(parsed.pathname) ||
+    EXPECTED_PATH_PREFIXES.some((prefix) => parsed.pathname.startsWith(prefix))
+  );
+};
 
 // Chrome's own "resource failed to load" console messages are generic and
 // carry no URL (`msg.text()` is just one of the two strings below, regardless

--- a/tests/e2e/e2e-harness.ts
+++ b/tests/e2e/e2e-harness.ts
@@ -50,19 +50,27 @@ export async function blockExternalNetwork(page: Page): Promise<void> {
 // require live Supabase credentials, which this E2E environment does not
 // provision — the same gap applies in CI until a maintainer wires up secrets
 // for the e2e job. Both routes already catch and log the failure rather than
-// throwing, so the page still renders; it's filtered out of the
-// console-error assertion below as a known environment limitation, not a
-// page defect.
+// throwing, so the page still renders; it's a known environment limitation,
+// not a page defect.
 const EXPECTED_500_PATHS = ['/api/words', '/api/channel-stats/'];
 
+const isKnownExpectedFailureUrl = (url: string): boolean =>
+  BLOCKED_HOSTS.some((host) => url.includes(host)) ||
+  url === BLOCKED_TWITCH_GQL ||
+  EXPECTED_500_PATHS.some((path) => url.includes(path));
+
 // Chrome's own "resource failed to load" console messages are generic and
-// carry no URL (`msg.text()` is just one of the two strings below,
-// regardless of which request failed), so they can't be attributed to a
-// specific request by text alone. `collectUnexpectedConsoleErrors` instead
-// tracks the network layer directly (`requestfailed` / `response`) to learn
-// *which* URLs are expected to fail, and only forgives that many generic
-// console messages — an unrelated failing script, stylesheet, or route still
-// surfaces as an unexpected error, since nothing decrements the count for it.
+// carry no URL (`msg.text()` is just one of the two strings below, regardless
+// of which request failed) — Playwright's `console` and `requestfailed`/
+// `response` events also aren't guaranteed to arrive in a correlated order,
+// so a per-page counter of "how many failures are expected right now" can't
+// be attributed to a specific message without risking exactly the failure
+// mode this suite exists to catch: an unrelated failure consuming budget left
+// over from an earlier *expected* one and going unreported. Rather than
+// guess, `collectUnexpectedFailures` drops these generic messages from the
+// console-error list entirely and answers "did anything unexpected fail?"
+// from the network layer instead, where every event carries its own URL and
+// there is nothing left to correlate.
 const GENERIC_RESOURCE_FAILURE = /^Failed to load resource: (net::ERR_FAILED|the server responded with a status of 5\d\d)/;
 
 // Produced by our own code (wos-words.ts / streamer channel-stats handling),
@@ -70,43 +78,37 @@ const GENERIC_RESOURCE_FAILURE = /^Failed to load resource: (net::ERR_FAILED|the
 // correlation needed.
 const EXPECTED_APP_LOG_NOISE = /Error (loading WOS dictionary|fetching channel stats)/;
 
-const isKnownExpectedFailureUrl = (url: string): boolean =>
-  BLOCKED_HOSTS.some((host) => url.includes(host)) ||
-  url === BLOCKED_TWITCH_GQL ||
-  EXPECTED_500_PATHS.some((path) => url.includes(path));
+export interface UnexpectedFailures {
+  /** Console `error` messages and uncaught page errors, excluding the unattributable generic resource-load noise (see `GENERIC_RESOURCE_FAILURE`) and known app-log noise. */
+  consoleErrors: string[];
+  /** URLs of failed requests / 4xx+5xx responses that aren't one of the known expected failures (`isKnownExpectedFailureUrl`) — the precise, URL-attributed check `consoleErrors` can't provide on its own. */
+  unexpectedRequestFailures: string[];
+}
 
-/** Starts collecting console errors and uncaught page errors on `page`. Call `blockExternalNetwork` first so aborted-resource noise isn't double counted. */
-export function collectUnexpectedConsoleErrors(page: Page): string[] {
-  const errors: string[] = [];
-  let expectedFailures = 0;
+/** Starts collecting console/page errors and unexpected network failures on `page`. Call `blockExternalNetwork` first so aborted-resource noise isn't double counted. */
+export function collectUnexpectedFailures(page: Page): UnexpectedFailures {
+  const result: UnexpectedFailures = { consoleErrors: [], unexpectedRequestFailures: [] };
 
-  page.on('requestfailed', (request) => {
-    if (isKnownExpectedFailureUrl(request.url())) expectedFailures++;
-  });
+  const noteIfUnexpected = (url: string) => {
+    if (!isKnownExpectedFailureUrl(url)) result.unexpectedRequestFailures.push(url);
+  };
 
+  page.on('requestfailed', (request) => { noteIfUnexpected(request.url()); });
   page.on('response', (response) => {
-    if (response.status() >= 400 && isKnownExpectedFailureUrl(response.url())) {
-      expectedFailures++;
-    }
+    if (response.status() >= 400) noteIfUnexpected(response.url());
   });
 
   page.on('console', (msg) => {
     if (msg.type() !== 'error') return;
     const text = msg.text();
-
     if (EXPECTED_APP_LOG_NOISE.test(text)) return;
-
-    if (GENERIC_RESOURCE_FAILURE.test(text) && expectedFailures > 0) {
-      expectedFailures--;
-      return;
-    }
-
-    errors.push(text);
+    if (GENERIC_RESOURCE_FAILURE.test(text)) return;
+    result.consoleErrors.push(text);
   });
 
   page.on('pageerror', (err) => {
-    errors.push(String(err));
+    result.consoleErrors.push(String(err));
   });
 
-  return errors;
+  return result;
 }

--- a/tests/e2e/e2e-harness.ts
+++ b/tests/e2e/e2e-harness.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Shared setup for the thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6
+ * / issue #152). Keeps the suite hermetic and independent of the sandbox's
+ * network policy, matching the "zero real network" convention the acceptance
+ * stream already established (tests/acceptance/network-mock.ts) — a CI run
+ * should not depend on whether fonts.googleapis.com or gql.twitch.tv happen
+ * to be reachable.
+ */
+
+// The base page loads Google Fonts as a render-blocking stylesheet. Aborting
+// it keeps navigation fast and deterministic; it has no bearing on whether
+// WoS+ itself works.
+const BLOCKED_HOSTS = ['fonts.googleapis.com', 'fonts.gstatic.com'];
+
+// Twitch's own unofficial GQL lookup (src/scripts/twitch-channel.ts),
+// exercised by the settings dialog's Save flow. `twitchChannelExists`
+// treats a failed/aborted request as "unknown" rather than "invalid", so
+// aborting it here doesn't block saving — it just keeps the channel-exists
+// round trip out of this suite's scope (real Twitch accounts are external
+// state, not something a smoke test should depend on).
+const BLOCKED_TWITCH_GQL = 'https://gql.twitch.tv/gql';
+
+export async function blockExternalNetwork(page: Page): Promise<void> {
+  await page.route(
+    (url) => BLOCKED_HOSTS.includes(url.hostname) || url.href === BLOCKED_TWITCH_GQL,
+    (route) => route.abort(),
+  );
+}
+
+// `/api/words` (loadWordsFromDb in wos-words.ts) requires live Supabase
+// credentials, which this E2E environment does not provision — the same gap
+// applies in CI until a maintainer wires up secrets for the e2e job. The
+// route already catches and logs the failure rather than throwing, so it
+// doesn't break the page; it's filtered out of the console-error assertion
+// below as a known environment limitation, not a page defect.
+//
+// Chrome's own "resource failed to load" console messages are generic and
+// carry no URL (`msg.text()` is just the string below, regardless of which
+// request failed), so the only way to attribute one is by message shape —
+// both of these are the *expected* shapes for requests this suite itself
+// intercepts/aborts (blocked hosts) or that require credentials this
+// environment doesn't have (`/api/words`). Anything else failing to load is
+// a real regression.
+const EXPECTED_CONSOLE_NOISE = [
+  /Error loading WOS dictionary/,
+  /^Failed to load resource: net::ERR_FAILED$/,
+  /^Failed to load resource: the server responded with a status of 500/,
+];
+
+/** Starts collecting console errors and uncaught page errors on `page`. Call `blockExternalNetwork` first so aborted-resource noise isn't double counted. */
+export function collectUnexpectedConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (EXPECTED_CONSOLE_NOISE.some((pattern) => pattern.test(text))) return;
+    errors.push(text);
+  });
+
+  page.on('pageerror', (err) => {
+    errors.push(String(err));
+  });
+
+  return errors;
+}

--- a/tests/e2e/e2e-harness.ts
+++ b/tests/e2e/e2e-harness.ts
@@ -22,41 +22,85 @@ const BLOCKED_HOSTS = ['fonts.googleapis.com', 'fonts.gstatic.com'];
 // state, not something a smoke test should depend on).
 const BLOCKED_TWITCH_GQL = 'https://gql.twitch.tv/gql';
 
+// The settings dialog's Save flow reconnects to the live WoS mirror game
+// (GameSpectator.connectToWosGame in wos-plus-main.ts), which opens a raw
+// WebSocket — socket.io configured with `transports: ['websocket']`, no HTTP
+// long-polling fallback — directly to this host. `page.route` only
+// intercepts HTTP(S) requests, never WebSocket connections, so blocking this
+// requires `page.routeWebSocket` as well.
+const BLOCKED_WOS_SOCKET_HOST = 'wos2.gartic.es';
+
 export async function blockExternalNetwork(page: Page): Promise<void> {
   await page.route(
     (url) => BLOCKED_HOSTS.includes(url.hostname) || url.href === BLOCKED_TWITCH_GQL,
     (route) => route.abort(),
   );
+
+  // Must be registered before navigation (Playwright only intercepts sockets
+  // opened after the route is armed). Not calling `ws.connectToServer()`
+  // leaves the connection mocked/unopened rather than reaching the real
+  // service.
+  await page.routeWebSocket(
+    (url) => url.hostname === BLOCKED_WOS_SOCKET_HOST,
+    () => {},
+  );
 }
 
-// `/api/words` (loadWordsFromDb in wos-words.ts) requires live Supabase
-// credentials, which this E2E environment does not provision — the same gap
-// applies in CI until a maintainer wires up secrets for the e2e job. The
-// route already catches and logs the failure rather than throwing, so it
-// doesn't break the page; it's filtered out of the console-error assertion
-// below as a known environment limitation, not a page defect.
-//
+// `/api/words` and `/api/channel-stats/*` (loadWordsFromDb / refreshChannelStats)
+// require live Supabase credentials, which this E2E environment does not
+// provision — the same gap applies in CI until a maintainer wires up secrets
+// for the e2e job. Both routes already catch and log the failure rather than
+// throwing, so the page still renders; it's filtered out of the
+// console-error assertion below as a known environment limitation, not a
+// page defect.
+const EXPECTED_500_PATHS = ['/api/words', '/api/channel-stats/'];
+
 // Chrome's own "resource failed to load" console messages are generic and
-// carry no URL (`msg.text()` is just the string below, regardless of which
-// request failed), so the only way to attribute one is by message shape —
-// both of these are the *expected* shapes for requests this suite itself
-// intercepts/aborts (blocked hosts) or that require credentials this
-// environment doesn't have (`/api/words`). Anything else failing to load is
-// a real regression.
-const EXPECTED_CONSOLE_NOISE = [
-  /Error loading WOS dictionary/,
-  /^Failed to load resource: net::ERR_FAILED$/,
-  /^Failed to load resource: the server responded with a status of 500/,
-];
+// carry no URL (`msg.text()` is just one of the two strings below,
+// regardless of which request failed), so they can't be attributed to a
+// specific request by text alone. `collectUnexpectedConsoleErrors` instead
+// tracks the network layer directly (`requestfailed` / `response`) to learn
+// *which* URLs are expected to fail, and only forgives that many generic
+// console messages — an unrelated failing script, stylesheet, or route still
+// surfaces as an unexpected error, since nothing decrements the count for it.
+const GENERIC_RESOURCE_FAILURE = /^Failed to load resource: (net::ERR_FAILED|the server responded with a status of 5\d\d)/;
+
+// Produced by our own code (wos-words.ts / streamer channel-stats handling),
+// not a generic Chrome message — specific enough on its own, no URL
+// correlation needed.
+const EXPECTED_APP_LOG_NOISE = /Error (loading WOS dictionary|fetching channel stats)/;
+
+const isKnownExpectedFailureUrl = (url: string): boolean =>
+  BLOCKED_HOSTS.some((host) => url.includes(host)) ||
+  url === BLOCKED_TWITCH_GQL ||
+  EXPECTED_500_PATHS.some((path) => url.includes(path));
 
 /** Starts collecting console errors and uncaught page errors on `page`. Call `blockExternalNetwork` first so aborted-resource noise isn't double counted. */
 export function collectUnexpectedConsoleErrors(page: Page): string[] {
   const errors: string[] = [];
+  let expectedFailures = 0;
+
+  page.on('requestfailed', (request) => {
+    if (isKnownExpectedFailureUrl(request.url())) expectedFailures++;
+  });
+
+  page.on('response', (response) => {
+    if (response.status() >= 400 && isKnownExpectedFailureUrl(response.url())) {
+      expectedFailures++;
+    }
+  });
 
   page.on('console', (msg) => {
     if (msg.type() !== 'error') return;
     const text = msg.text();
-    if (EXPECTED_CONSOLE_NOISE.some((pattern) => pattern.test(text))) return;
+
+    if (EXPECTED_APP_LOG_NOISE.test(text)) return;
+
+    if (GENERIC_RESOURCE_FAILURE.test(text) && expectedFailures > 0) {
+      expectedFailures--;
+      return;
+    }
+
     errors.push(text);
   });
 

--- a/tests/e2e/settings-dialog.spec.ts
+++ b/tests/e2e/settings-dialog.spec.ts
@@ -4,11 +4,17 @@ import { blockExternalNetwork } from './e2e-harness';
 /**
  * Thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6 / issue #152).
  *
- * Covers the settings dialog's URL round trip only. Saving also fires real
- * connections to the live WoS mirror socket and Twitch chat (out of scope
- * per the plan — those protocols are already covered deterministically by
- * the fixture-driven worker tests), so this test doesn't assert on console
- * output the way smoke.spec.ts does; it only checks where Save lands the URL.
+ * Covers the settings dialog's URL round trip only. Saving also points the
+ * Twitch chat iframe at a real, unmocked `www.twitch.tv/embed/...` URL (out
+ * of scope per the plan — that protocol is already covered deterministically
+ * by the fixture-driven worker tests), so this test doesn't assert on
+ * console output the way smoke.spec.ts does; it only checks where Save lands
+ * the URL. `blockExternalNetwork` still blocks the WoS mirror WebSocket Save
+ * also opens, so the suite stays hermetic even though this test doesn't rely
+ * on that for its own assertions. `wos.gg` below is only the mirror-URL
+ * *input* the form validates — not a host this suite talks to; the actual
+ * live connection Save makes is the WebSocket to `wos2.gartic.es`, which
+ * `blockExternalNetwork` intercepts.
  */
 
 const MIRROR_URL = 'https://wos.gg/r/4fdfc856-0328-4384-a882-8377dcb5a4f6';

--- a/tests/e2e/settings-dialog.spec.ts
+++ b/tests/e2e/settings-dialog.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { blockExternalNetwork } from './e2e-harness';
+
+/**
+ * Thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6 / issue #152).
+ *
+ * Covers the settings dialog's URL round trip only. Saving also fires real
+ * connections to the live WoS mirror socket and Twitch chat (out of scope
+ * per the plan — those protocols are already covered deterministically by
+ * the fixture-driven worker tests), so this test doesn't assert on console
+ * output the way smoke.spec.ts does; it only checks where Save lands the URL.
+ */
+
+const MIRROR_URL = 'https://wos.gg/r/4fdfc856-0328-4384-a882-8377dcb5a4f6';
+const TWITCH_CHANNEL = 'somestreamer';
+
+test('player settings dialog round-trips values into URL params', async ({ page }) => {
+  await blockExternalNetwork(page);
+  await page.goto('/player', { waitUntil: 'domcontentloaded' });
+
+  const dialog = page.locator('#player-settings');
+  await expect(dialog).toBeVisible();
+
+  await page.fill('#mirror-url-input', MIRROR_URL);
+  await page.fill('#twitch-channel-input', TWITCH_CHANNEL);
+  // The toggle switch hides its native checkbox off-screen behind the
+  // visible `.toggle-slider`; click the slider like a user would rather than
+  // the input Playwright can't see.
+  await page
+    .locator('label:has(#chat-enabled-input) .toggle-slider')
+    .click();
+  await expect(page.locator('#chat-enabled-input')).not.toBeChecked();
+
+  await page.click('.settings-dialog__save');
+
+  await expect(dialog).not.toBeVisible();
+
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get('mirrorUrl'))
+    .toBe(MIRROR_URL);
+
+  const params = new URL(page.url()).searchParams;
+  expect(params.get('twitchChannel')).toBe(TWITCH_CHANNEL);
+  expect(params.get('chat')).toBe('false');
+  expect(params.get('board')).toBe('true');
+  expect(params.get('clearSound')).toBe('true');
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { blockExternalNetwork, collectUnexpectedConsoleErrors } from './e2e-harness';
+import { blockExternalNetwork, collectUnexpectedFailures } from './e2e-harness';
 
 /**
  * Thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6 / issue #152).
@@ -21,7 +21,7 @@ test('GET /api/health returns 200 through the real Workers runtime', async ({ re
 for (const path of ['/', '/player', '/streamer']) {
   test(`${path} loads without unexpected console errors`, async ({ page }) => {
     await blockExternalNetwork(page);
-    const errors = collectUnexpectedConsoleErrors(page);
+    const { consoleErrors, unexpectedRequestFailures } = collectUnexpectedFailures(page);
 
     const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
     expect(response?.status()).toBe(200);
@@ -30,9 +30,34 @@ for (const path of ['/', '/player', '/streamer']) {
     // before asserting the console stayed clean.
     await page.waitForTimeout(500);
 
-    expect(errors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+    expect(unexpectedRequestFailures).toEqual([]);
   });
 }
+
+test('an unrelated request failure still surfaces after a known expected one', async ({ page }) => {
+  // Regression for a review finding: an earlier version tracked "how many
+  // failures are currently expected" as a single page-global counter, which
+  // console/network events could decrement out of order — letting a later,
+  // genuinely unrelated failure silently consume budget left over from an
+  // earlier expected one (e.g. /api/words' known 500, see EXPECTED_500_PATHS
+  // in e2e-harness.ts) and go unreported. collectUnexpectedFailures now
+  // judges each request by its own URL instead, so this must always surface.
+  await blockExternalNetwork(page);
+  await page.route('**/definitely-not-a-real-route', (route) => route.abort());
+  const { unexpectedRequestFailures } = collectUnexpectedFailures(page);
+
+  // /player's page load already triggers the known-expected /api/words
+  // failure (no Supabase credentials in this environment) before the
+  // unrelated request below ever fires.
+  await page.goto('/player', { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => fetch('/definitely-not-a-real-route').catch(() => {}));
+  await page.waitForTimeout(300);
+
+  expect(unexpectedRequestFailures).toEqual(
+    expect.arrayContaining([expect.stringContaining('/definitely-not-a-real-route')]),
+  );
+});
 
 for (const path of ['/player', '/streamer']) {
   test(`${path} opens the settings dialog when required query params are missing`, async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { blockExternalNetwork, collectUnexpectedConsoleErrors } from './e2e-harness';
+
+/**
+ * Thin E2E smoke layer (AGENTIC-TESTING-PLAN.md Phase 6 / issue #152).
+ *
+ * Runs against a production build through the real Cloudflare Workers
+ * runtime (`wrangler dev`, see playwright.config.ts's `webServer`) — the one
+ * layer that catches `prerender = false` / `locals.runtime.env`
+ * misconfigurations that unit and acceptance tests structurally cannot see,
+ * because they never invoke a route through an actual Workers runtime.
+ */
+
+test('GET /api/health returns 200 through the real Workers runtime', async ({ request }) => {
+  const response = await request.get('/api/health');
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body).toMatchObject({ status: 'ok' });
+});
+
+for (const path of ['/', '/player', '/streamer']) {
+  test(`${path} loads without unexpected console errors`, async ({ page }) => {
+    await blockExternalNetwork(page);
+    const errors = collectUnexpectedConsoleErrors(page);
+
+    const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(response?.status()).toBe(200);
+
+    // Give deferred scripts (dialog init, worker startup) a moment to settle
+    // before asserting the console stayed clean.
+    await page.waitForTimeout(500);
+
+    expect(errors).toEqual([]);
+  });
+}
+
+for (const path of ['/player', '/streamer']) {
+  test(`${path} opens the settings dialog when required query params are missing`, async ({ page }) => {
+    await blockExternalNetwork(page);
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    const dialog = page.locator('dialog.settings-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveJSProperty('open', true);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -83,6 +83,10 @@ export default defineConfig({
       '.idea',
       '.git',
       '.cache',
+      // Playwright specs (tests/e2e/**), run via `pnpm run test:e2e`, not
+      // Vitest — they use @playwright/test's own `test`/`expect`, which
+      // collides with Vitest's globals if picked up here.
+      'tests/e2e',
     ],
   },
 


### PR DESCRIPTION
## What changed

Closes the last open phase in `AGENTIC-TESTING-PLAN.md`: [#152](https://github.com/clarkio/wos-plus/issues/152), the thin Playwright E2E smoke layer. With this, every phase in the plan's status table is done — only the tracking epic ([#157](https://github.com/clarkio/wos-plus/issues/157)) stays open.

Explicit maintainer sign-off for this architecture-tier change (new dependency, new E2E harness against `wrangler dev`) was obtained in conversation before any implementation started, per `CLAUDE.md` §5.

Seven Playwright tests run against a real production build under `wrangler dev` — the only layer that exercises `prerender = false` / `locals.runtime.env` through an actual Cloudflare Workers runtime instead of an invoked handler:

- `GET /api/health` returns 200 through the real runtime.
- `/`, `/player`, `/streamer` load without unexpected console errors.
- `/player` and `/streamer` open the settings dialog when required query params are missing.
- The settings dialog's Save flow round-trips values into URL params.

WoS WebSocket and Twitch chat connections stay explicitly out of scope, per the issue — that protocol handling is already covered deterministically by the fixture-driven worker tests.

**The sandbox assumption the plan flagged going in — "`wrangler dev` may not run in a sandbox at all" — turned out false.** It runs fine here (verified with plain `curl` before writing any spec). Two environment quirks needed working around, not signs the approach doesn't work: `wrangler dev` only binds IPv4, so Chromium resolving `localhost` to `::1` first hangs (`playwright.config.ts` uses `127.0.0.1` explicitly); and Chromium refuses to start its own sandbox as root, worked around with `--no-sandbox`, gated on a `PLAYWRIGHT_CHROMIUM_PATH` env var so a normal non-root CI runner is unaffected.

## Verification

- [x] Spec in `specs/` added or updated — N/A, no game/API behavior changed
- [x] Tests written or updated *before or with* the implementation — this PR *is* the test suite (Phase 6's whole scope)
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **`@playwright/test` 1.62.1**, exact-pinned — justification below
- [x] Code authored with AI assistance: **yes**

### Local gate results

```
pnpm run check
  0 errors, 0 warnings, 15 hints (matches CLAUDE.md §4 baseline)

pnpm run lint
  clean, --max-warnings 0

pnpm run test:coverage
  Test Files  19 passed (19)
  Tests  692 passed | 3 todo (695)
  Statements 91.41% / Branches 87.77% / Functions 88.94% / Lines 92.08%
  (unchanged — matches the documented baseline exactly, since tests/e2e/
  is excluded from Vitest's include set)

pnpm run build
  Complete!

pnpm run test:e2e (PLAYWRIGHT_CHROMIUM_PATH=/opt/pw-browsers/chromium)
  7 passed (14.7s)
```

## New dependency: `@playwright/test`

- **What it does**: browser automation + test runner for the E2E layer.
- **Why not hand-rolled**: driving a real Chromium instance against a real `wrangler dev` server isn't something worth reimplementing; Playwright is the standard tool for exactly this, and is what the plan's Phase 6 specified from the start.
- **Maintenance status**: actively maintained by Microsoft, very widely used, exact-pinned at `1.62.1` per `CLAUDE.md` §2.3.

## Notes for the reviewer

- **A named, not hidden, gap**: `.github/workflows/e2e.yml` provisions no Supabase credentials, so `/player`/`/streamer`'s in-page word-dictionary and channel-stats fetches fail there the same way they would locally without `.dev.vars` — the routes already catch and log rather than throw, so pages still render fine. `tests/e2e/e2e-harness.ts`'s console-error filter names this exact gap explicitly (by message shape, since Chrome's own resource-failure console messages carry no URL) rather than silently swallowing all console errors. Wiring real or sandboxed Supabase credentials into the CI job is future work — happy to do it here if you'd rather not leave it open, just say the word.
- `docs/BRANCH-PROTECTION.md`'s `e2e` row is now marked available but **not yet ticked as a required check** — same maintainer action as the other rows in that table (`analyze`, `dependency-review`).
- `.github/copilot-instructions.md` was **not** updated for this phase, matching how the mutation-testing addition (#154) was handled — it documents the Vitest-based two-stream contract only; `CLAUDE.md` §9 is the authoritative doc for the E2E layer, per the existing precedent in this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcECLoxrfBWxqxrRjCcPXM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Playwright end-to-end smoke testing for key routes, health checks, and player settings.
  * Added a command to run the end-to-end test suite locally.
  * Added automated CI execution with failure reports.

* **Documentation**
  * Documented test coverage, setup, limitations, and branch-protection status.

* **Chores**
  * Excluded end-to-end tests and generated reports from standard test collection and version control.
  * Added isolated test execution to reduce unrelated external network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->