### PR TITLE
Repair boards with invalid stored words (make saveBoard trigger PUT for impossible words)

### DIFF
--- a/specs/boards.md
+++ b/specs/boards.md
@@ -249,10 +249,11 @@ presence means the stored copy is wrong.
 
 ### Scenario: a corrupted stored board is replaced by a clean capture
 
-- **Given** the stored board `CAUTION` has the same word in two slots
+- **Given** the stored board `CAUTION` has the same word in two slots, or has a
+  word that cannot be formed from the letters in `CAUTION`
 - **And** WoS+ has just captured `CAUTION` cleanly, with every slot a different
   word
-- **When** WoS+ offers the clean capture as a repair
+- **When** WoS+ saves the clean capture
 - **Then** the stored board's slots are replaced by the clean ones
 
 ### Scenario: a repair also fills in a missing channel and language

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -1,4 +1,4 @@
-import { findRedundantWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../lib/board-utils';
+import { findRedundantWords, hasInvalidWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../lib/board-utils';
 
 export interface ChannelStats {
   allTimePersonalBest: number;
@@ -101,9 +101,9 @@ async function fetchExistingBoard(boardId: string): Promise<{ exists: boolean; b
   }
 }
 
-// Replaces the slots of an already-stored board that was saved with redundant
-// words (issue #119). The server only accepts this update when the stored
-// board is actually corrupted, so a clean board can never be overwritten.
+// Replaces the slots of an already-stored board that was saved with corrupted
+// words (issues #119 and #195). The server only accepts this update when the
+// stored board is actually corrupted, so a clean board can never be overwritten.
 async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: string | null, languageCode: string) {
   try {
     const response = await fetch(`/api/boards/${encodeURIComponent(boardId)}`, {
@@ -136,6 +136,13 @@ async function updateBoardSlots(boardId: string, slots: Slot[], twitchChannel: s
   } catch (error) {
     console.error('Error updating board with clean slots:', error);
   }
+}
+
+function storedBoardCorruptionReason(board: Board | null, boardId: string): 'redundant words' | 'invalid words' | null {
+  if (!board) return null;
+  if (hasRedundantWords(board.slots)) return 'redundant words';
+  if (hasInvalidWords(board.slots, boardId)) return 'invalid words';
+  return null;
 }
 
 export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: string, languageCode?: string) {
@@ -220,11 +227,12 @@ export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: 
   try {
     const { exists, board: existingBoard } = await fetchExistingBoard(cleanBoardId);
     if (exists) {
-      // Self-healing (issue #119): if the stored copy of this board was saved
-      // with redundant words, replace its slots with this clean capture
-      // instead of skipping the save.
-      if (existingBoard && hasRedundantWords(existingBoard.slots)) {
-        console.warn(`Board ${cleanBoardId} exists with redundant words; updating it with the clean version.`);
+      // Self-healing (issues #119 and #195): if the stored copy of this board
+      // has redundant or impossible words, replace its slots with this clean
+      // capture instead of skipping the save.
+      const corruptionReason = storedBoardCorruptionReason(existingBoard, cleanBoardId);
+      if (corruptionReason) {
+        console.warn(`Board ${cleanBoardId} exists with ${corruptionReason}; updating it with the clean version.`);
         return await updateBoardSlots(cleanBoardId, slots, cleanTwitchChannel, requestedLanguageCode ?? 'en');
       }
 

--- a/tests/unit/db-service.test.ts
+++ b/tests/unit/db-service.test.ts
@@ -480,6 +480,44 @@ describe('db-service module', () => {
         );
       });
 
+      it('should update the existing board when the stored version has a word that cannot be formed from the board letters', async () => {
+        const cleanCautionSlots: Slot[] = [
+          { letters: ['a', 'c', 't'], user: 'a', hitMax: false, word: 'act' },
+          { letters: ['c', 'o', 'i', 'n'], user: 'b', hitMax: false, word: 'coin' },
+        ];
+        const storedCorruptBoard = {
+          id: 'CAUTION',
+          slots: [
+            { letters: ['a', 'c', 't', 'o', 'r'], user: 'a', hitMax: false, word: 'actor' },
+            { letters: ['c', 'o', 'i', 'n'], user: 'b', hitMax: false, word: 'coin' },
+          ],
+          created_at: '2024-01-01T00:00:00Z',
+        };
+        const updatedBoard = [{ id: 'CAUTION', slots: cleanCautionSlots }];
+
+        global.fetch = vi.fn()
+          .mockImplementationOnce(() => mockFetchResponse(storedCorruptBoard))
+          .mockImplementationOnce(() => mockFetchResponse(updatedBoard));
+
+        const result = await saveBoard('CAUTION', cleanCautionSlots);
+
+        expect(global.fetch).toHaveBeenNthCalledWith(
+          2,
+          '/api/boards/CAUTION',
+          expect.objectContaining({
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ slots: cleanCautionSlots, language_code: 'en' }),
+          })
+        );
+        expect(result).toEqual(updatedBoard);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Board CAUTION exists with invalid words; updating it with the clean version.'
+        );
+      });
+
       it('should self-heal when the stored slots column is a JSON string with redundant words', async () => {
         const storedCorruptBoard = {
           id: 'TEST',
@@ -506,9 +544,13 @@ describe('db-service module', () => {
       });
 
       it('should not update the existing board when the stored slots column is a clean JSON string', async () => {
+        const cleanTestSlots: Slot[] = [
+          validSlots[0],
+          { letters: ['s', 'e', 't'], user: 'anotheruser', hitMax: true, word: 'set' },
+        ];
         const storedCleanBoard = {
           id: 'TEST',
-          slots: JSON.stringify(validSlots),
+          slots: JSON.stringify(cleanTestSlots),
           created_at: '2024-01-01T00:00:00Z',
         };
 
@@ -523,9 +565,13 @@ describe('db-service module', () => {
       });
 
       it('should not update the existing board when the stored version is clean', async () => {
+        const cleanTestSlots: Slot[] = [
+          validSlots[0],
+          { letters: ['s', 'e', 't'], user: 'anotheruser', hitMax: true, word: 'set' },
+        ];
         const storedCleanBoard = {
           id: 'TEST',
-          slots: validSlots,
+          slots: cleanTestSlots,
           created_at: '2024-01-01T00:00:00Z',
         };
 


### PR DESCRIPTION
### Motivation

- Close the gap where `saveBoard()` only self-healed boards with redundant words and ignored stored slots that contained words impossible to form from the board id, leaving archived boards silently broken. 

### Description

- Import `hasInvalidWords` and add a small helper `storedBoardCorruptionReason()` in `src/scripts/db-service.ts` to detect whether an existing board has `redundant words` or `invalid words`. 
- Widen the `saveBoard()` existing-board branch to call `updateBoardSlots()` when the stored board has either redundant or invalid words and log the appropriate reason. 
- Update `specs/boards.md` to clarify the repair scenario and add a unit test in `tests/unit/db-service.test.ts` that reproduces the `CAUTION`/`ACTOR` case and asserts a `PUT /api/boards/CAUTION` is performed. 

### Testing

- ✅ Ran the unit tests for the modified file with `pnpm exec vitest run tests/unit/db-service.test.ts` and the updated file's tests passed. 
- ✅ Ran the full suite and checks with `pnpm run check`, `pnpm run lint`, `pnpm run test:coverage`, and `pnpm run build`, all of which completed successfully and met existing coverage/lint gates. 
- ✅ Verified the new regression test ensures `saveBoard()` triggers the repair `PUT` when a stored board contains words that cannot be formed from the board letters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80e26ce5788324bb4c54cbf739e708)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Board self-healing now detects stored words that are invalid or repeated.
  * Corrupted boards are automatically replaced with a clean capture and the specific corruption is reported.

* **Tests**
  * Added coverage for boards containing unformable words.
  * Expanded validation for clean boards stored in supported formats.

* **Documentation**
  * Updated repair scenario guidance to describe automatic saving of clean board captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->