### PR TITLE
Add post-authorization chatbot setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,7 +366,9 @@ runtime.
   slower layer with its own CI job (`.github/workflows/e2e.yml`, job `e2e`),
   not bundled into `build`.
 - **Deliberately narrow, per the plan's "thin E2E" framing**: page loads for
-  `/`, `/player`, `/streamer` without unexpected console errors; `/api/health`
+  `/`, `/player`, `/streamer`, `/bot`, `/bot/setup` without unexpected console
+  errors; the post-authorization chatbot setup steps on `/bot/setup`
+  (issue [#178](https://github.com/clarkio/wos-plus/issues/178)); `/api/health`
   returning 200 through the real Workers runtime; the settings dialog opening
   when required query params are missing; and the dialog's Save flow
   round-tripping values into URL params. WoS WebSocket and Twitch chat

--- a/src/pages/bot.astro
+++ b/src/pages/bot.astro
@@ -15,6 +15,7 @@ import Twitch from "../components/Icons/Twitch.astro";
       <nav class="sp-nav-links">
         <a href="/">Home</a>
         <a href="#features">Features</a>
+        <a href="/bot/setup">Setup</a>
         <a href="#commands" class="sp-nav-launch">Add Bot</a>
       </nav>
     </header>
@@ -89,10 +90,11 @@ import Twitch from "../components/Icons/Twitch.astro";
 
         <div class="sp-feature sp-feature-yellow">
           <div class="sp-feature-icon">⚡</div>
-          <h3>Zero configuration</h3>
+          <h3>Quick setup</h3>
           <p>
-            Authorize once and the bot auto-joins your channel. No setup
-            files, no config, no maintenance required.
+            Authorize once and the bot auto-joins your channel. Two chat
+            commands connect it to your game &mdash; no setup files, no
+            maintenance. <a href="/bot/setup">See the setup steps</a>.
           </p>
         </div>
       </div>
@@ -149,10 +151,10 @@ import Twitch from "../components/Icons/Twitch.astro";
         </div>
         <div class="sp-step sp-step-2">
           <div class="sp-step-num">2</div>
-          <div class="sp-step-label">Bot joins your channel</div>
+          <div class="sp-step-label">Mod the bot &amp; connect your game</div>
           <p class="sp-step-desc">
-            After authorization, WoS+ Bot automatically joins your Twitch
-            chat. No extra setup needed.
+            In your chat, run <code>/mod WoSPlusBot</code>, then send your
+            Words on Stream mirror link with <code>!mirror set</code>.
           </p>
         </div>
         <div class="sp-step sp-step-3">
@@ -164,6 +166,9 @@ import Twitch from "../components/Icons/Twitch.astro";
           </p>
         </div>
       </div>
+      <p class="sp-steps-footer">
+        <a href="/bot/setup">Full setup instructions →</a>
+      </p>
     </section>
 
     <!-- ===================== CTA ===================== -->
@@ -631,6 +636,32 @@ import Twitch from "../components/Icons/Twitch.astro";
     line-height: 1.5;
     color: rgba(22, 2, 39, 0.65);
     margin: 0;
+  }
+
+  .sp-step-desc code {
+    background: rgba(22, 2, 39, 0.08);
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    overflow-wrap: anywhere;
+  }
+
+  .sp-steps-footer {
+    margin: 28px 0 0;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 16px;
+  }
+
+  .sp-steps-footer a {
+    color: var(--sp-cyan);
+    text-decoration: none;
+  }
+
+  .sp-feature-yellow p a {
+    color: var(--sp-bg-deep);
+    font-weight: 700;
   }
 
   /* ===================== CTA ===================== */

--- a/src/pages/bot/setup.astro
+++ b/src/pages/bot/setup.astro
@@ -98,7 +98,8 @@ import Twitch from "../../components/Icons/Twitch.astro";
             </p>
             <p class="sp-setup-note">
               It looks like
-              <code>https://wos.gg/#/mirror/&lt;code&gt;</code>. This is the
+              <code>https://wos.gg/r/4fdfc856-0328-4384-a882-8377dcb5a4f6</code>
+              &mdash; the WoS host followed by your game's room id. This is the
               link that lets WoS+ follow along with your game.
             </p>
           </div>

--- a/src/pages/bot/setup.astro
+++ b/src/pages/bot/setup.astro
@@ -1,0 +1,574 @@
+---
+import WosBaseLayout from "../../layouts/WosBaseLayout.astro";
+import Twitch from "../../components/Icons/Twitch.astro";
+
+// The page the bot service redirects to after a successful Twitch
+// authorization (issue #178). It is also linked from /bot so a streamer who
+// authorized earlier — or who lost the redirect — can find the same steps
+// again; nothing on it depends on having arrived from the OAuth callback.
+---
+
+<WosBaseLayout
+  title="Set up WoS+ Bot | Twitch Chatbot for Words on Stream"
+  description="You authorized WoS+ Bot. Follow these steps to finish setting it up in your Twitch stream: verify the bot, mod it, and connect your Words on Stream mirror link."
+  keywords="words on stream, wos, chatbot, twitch bot, wos plus bot, setup, mirror link, mod the bot"
+>
+  <div class="sp-bot">
+    <!-- ===================== Nav ===================== -->
+    <header class="sp-nav">
+      <a href="/" class="sp-brand">WoS<span class="sp-brand-plus">+</span></a>
+      <nav class="sp-nav-links">
+        <a href="/">Home</a>
+        <a href="/bot">Bot</a>
+        <a href="/bot#commands" class="sp-nav-launch">Commands</a>
+      </nav>
+    </header>
+
+    <!-- ===================== Hero ===================== -->
+    <section class="sp-hero">
+      <div class="sp-hero-content">
+        <span class="sp-hero-badge">
+          <Twitch width={16} height={16} />
+          Authorization complete
+        </span>
+        <h1 class="sp-hero-title">
+          FINISH <span class="sp-hero-accent">SETUP</span>
+        </h1>
+        <p class="sp-hero-sub">
+          WoS+ Bot is authorized for your channel. Three short steps in your
+          own Twitch chat and it will start tracking your Words on Stream
+          games.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== Steps ===================== -->
+    <section class="sp-section" data-setup-steps>
+      <ol class="sp-setup">
+        <li class="sp-setup-item sp-setup-1">
+          <div class="sp-setup-num">1</div>
+          <div class="sp-setup-body">
+            <h2>Check the bot is in your chat</h2>
+            <p>
+              Go to your own Twitch chat and send <code>!ping</code>. WoS+ Bot
+              should reply with <code>Pong!</code> within a second or two.
+            </p>
+            <p class="sp-setup-note">
+              No reply? Give it a minute and try again &mdash; the bot joins
+              shortly after you authorize. If it still says nothing, re-run
+              <a href="/bot">Add Bot to Your Channel</a>.
+            </p>
+          </div>
+        </li>
+
+        <li class="sp-setup-item sp-setup-2">
+          <div class="sp-setup-num">2</div>
+          <div class="sp-setup-body">
+            <h2>Give the bot moderator permissions</h2>
+            <p>
+              In your chat, send <code>/mod WoSPlusBot</code>. This matters for
+              two reasons:
+            </p>
+            <ul class="sp-setup-list">
+              <li>
+                <strong>Rate limits.</strong> Twitch throttles ordinary
+                accounts that send a lot of chat messages. Without mod, the bot
+                gets rate-limited during busy games and its replies stop
+                arriving.
+              </li>
+              <li>
+                <strong>Links.</strong> The bot posts links (game boards, word
+                lists). If your AutoMod or a moderation bot blocks links from
+                non-mods, WoS+ Bot will get timed out or banned in your own
+                channel. Modding it &mdash; or explicitly permitting it to post
+                links in your moderation setup &mdash; prevents that.
+              </li>
+            </ul>
+          </div>
+        </li>
+
+        <li class="sp-setup-item sp-setup-3">
+          <div class="sp-setup-num">3</div>
+          <div class="sp-setup-body">
+            <h2>Copy your Words on Stream mirror link</h2>
+            <p>
+              In Words on Stream, open the <strong>settings menu</strong> (the
+              gear icon) and find the <strong>mirror link</strong> &mdash; the
+              spectator link for your game. Copy it to your clipboard.
+            </p>
+            <p class="sp-setup-note">
+              It looks like
+              <code>https://wos.gg/#/mirror/&lt;code&gt;</code>. This is the
+              link that lets WoS+ follow along with your game.
+            </p>
+          </div>
+        </li>
+
+        <li class="sp-setup-item sp-setup-4">
+          <div class="sp-setup-num">4</div>
+          <div class="sp-setup-body">
+            <h2>Send the mirror link to the bot</h2>
+            <p>
+              Back in your Twitch chat, send the mirror command with the link
+              you just copied:
+            </p>
+            <pre class="sp-setup-code"><code>!mirror set &lt;your mirror link&gt;</code></pre>
+            <p>
+              Replace <code>&lt;your mirror link&gt;</code> entirely &mdash;
+              angle brackets included &mdash; with the link from step 3.
+            </p>
+            <p class="sp-setup-note">
+              WoS+ Bot replies in chat confirming the mirror link was set. If
+              you see that confirmation, you are done: play as usual and the
+              bot tracks the session.
+            </p>
+          </div>
+        </li>
+      </ol>
+    </section>
+
+    <!-- ===================== CTA ===================== -->
+    <section class="sp-cta">
+      <div class="sp-cta-content">
+        <h2 class="sp-cta-title">Something not working?</h2>
+        <p class="sp-cta-sub">
+          Check the command list, or re-authorize the bot for your channel.
+        </p>
+        <div class="sp-cta-row">
+          <a href="/bot#commands" class="sp-btn sp-btn-yellow">See Commands →</a>
+          <a
+            href="https://wos-plus-bot.onrender.com/auth"
+            class="sp-btn sp-btn-cyan"
+            target="_blank"
+            rel="noopener"
+          >
+            <Twitch width={18} height={18} />
+            Re-authorize
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== Footer ===================== -->
+    <footer class="sp-footer">
+      <a href="/" class="sp-footer-brand">WoS<span class="sp-footer-plus">+</span></a>
+      <div class="sp-footer-links">
+        <a href="/">Home</a>
+        <a href="/bot">Bot</a>
+        <a href="/streamer">Streamer View</a>
+        <a href="https://wos.gg" target="_blank" rel="noopener">Words on Stream</a>
+      </div>
+      <div class="sp-footer-by">
+        Made with 💜 by
+        <a href="https://twitch.tv/clarkio" target="_blank" rel="noopener">clarkio</a>
+      </div>
+    </footer>
+  </div>
+</WosBaseLayout>
+
+<style>
+  .sp-bot {
+    min-height: 100vh;
+    overflow-x: hidden;
+    background: var(--sp-bg);
+    font-family: var(--font-ui);
+    color: var(--sp-ink);
+  }
+
+  /* ===================== Nav ===================== */
+  .sp-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 32px;
+    background: var(--sp-cyan);
+    color: var(--sp-cyan-ink);
+  }
+
+  .sp-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 24px;
+    color: var(--sp-bg-deep);
+    text-decoration: none;
+  }
+
+  .sp-brand-plus {
+    color: var(--sp-purple);
+  }
+
+  .sp-nav-links {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+  }
+
+  .sp-nav-links a {
+    color: var(--sp-cyan-ink);
+    text-decoration: none;
+  }
+
+  .sp-nav-launch {
+    padding: 9px 20px;
+    border-radius: 999px;
+    background: var(--sp-bg-deep);
+    color: #fff !important;
+    box-shadow: 3px 3px 0 var(--sp-cyan-shadow);
+    transition: transform 0.12s ease;
+  }
+
+  .sp-nav-launch:hover {
+    transform: translate(-1px, -1px);
+  }
+
+  /* ===================== Hero ===================== */
+  .sp-hero {
+    padding: 54px 32px 20px;
+    max-width: 1240px;
+    margin: 0 auto;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .sp-hero-content {
+    max-width: 680px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .sp-hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: var(--sp-purple);
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 22px;
+    box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .sp-hero-badge :global(svg) {
+    fill: #fff;
+  }
+
+  .sp-hero-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 68px;
+    line-height: 0.95;
+    letter-spacing: -2px;
+    color: #fff;
+    text-shadow: 5px 5px 0 var(--sp-purple);
+  }
+
+  .sp-hero-accent {
+    color: var(--sp-yellow);
+    text-shadow: 5px 5px 0 var(--sp-bg-deep);
+  }
+
+  .sp-hero-sub {
+    margin: 26px 0 0;
+    font-size: 19px;
+    line-height: 1.5;
+    color: var(--sp-ink-muted);
+    max-width: 560px;
+    font-weight: 500;
+  }
+
+  /* ===================== Steps ===================== */
+  .sp-section {
+    max-width: 940px;
+    margin: 0 auto;
+    padding: 40px 32px 20px;
+  }
+
+  .sp-setup {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+
+  .sp-setup-item {
+    display: flex;
+    gap: 20px;
+    padding: 26px 28px;
+    border-radius: 18px;
+    background: #fff;
+    color: var(--sp-bg-deep);
+    text-align: left;
+  }
+
+  .sp-setup-1 { box-shadow: 5px 5px 0 var(--sp-purple); }
+  .sp-setup-2 { box-shadow: 5px 5px 0 var(--sp-pink); }
+  .sp-setup-3 { box-shadow: 5px 5px 0 var(--sp-cyan); }
+  .sp-setup-4 { box-shadow: 5px 5px 0 var(--sp-yellow); }
+
+  .sp-setup-num {
+    flex: 0 0 auto;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--sp-purple);
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 22px;
+  }
+
+  .sp-setup-2 .sp-setup-num { background: var(--sp-pink); }
+  .sp-setup-3 .sp-setup-num { background: var(--sp-cyan); color: var(--sp-cyan-ink); }
+  .sp-setup-4 .sp-setup-num { background: var(--sp-yellow-shadow); color: var(--sp-bg-deep); }
+
+  .sp-setup-body {
+    min-width: 0;
+  }
+
+  .sp-setup-body h2 {
+    margin: 6px 0 10px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 22px;
+  }
+
+  .sp-setup-body p {
+    margin: 0 0 10px;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: rgba(22, 2, 39, 0.78);
+  }
+
+  .sp-setup-list {
+    margin: 0 0 10px;
+    padding-left: 20px;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: rgba(22, 2, 39, 0.78);
+  }
+
+  .sp-setup-list li {
+    margin-bottom: 8px;
+  }
+
+  .sp-setup-note {
+    font-size: 0.92rem !important;
+    color: rgba(22, 2, 39, 0.6) !important;
+  }
+
+  .sp-setup-body code {
+    background: rgba(120, 60, 220, 0.12);
+    color: var(--sp-purple-deep);
+    padding: 0.125rem 0.4rem;
+    border-radius: 0.3rem;
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    overflow-wrap: anywhere;
+  }
+
+  .sp-setup-code {
+    margin: 0 0 10px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    background: var(--sp-bg-deep);
+    overflow-x: auto;
+  }
+
+  .sp-setup-code code {
+    background: none;
+    color: var(--sp-yellow);
+    font-size: 1rem;
+    padding: 0;
+  }
+
+  .sp-setup-body a {
+    color: var(--sp-purple);
+    font-weight: 600;
+  }
+
+  /* ===================== Buttons ===================== */
+  .sp-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 30px;
+    border-radius: 14px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 18px;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.12s ease;
+  }
+
+  .sp-btn:hover {
+    transform: translate(-1px, -1px);
+  }
+
+  .sp-btn:active {
+    transform: translate(2px, 2px);
+  }
+
+  .sp-btn-cyan {
+    background: var(--sp-cyan);
+    color: var(--sp-cyan-ink);
+    box-shadow: 5px 5px 0 var(--sp-cyan-shadow);
+  }
+
+  .sp-btn-cyan :global(svg) {
+    fill: var(--sp-cyan-ink);
+  }
+
+  .sp-btn-yellow {
+    background: var(--sp-yellow);
+    color: var(--sp-bg-deep);
+    box-shadow: 5px 5px 0 var(--sp-yellow-shadow);
+  }
+
+  /* ===================== CTA ===================== */
+  .sp-cta {
+    max-width: 940px;
+    margin: 0 auto;
+    padding: 20px 32px 70px;
+  }
+
+  .sp-cta-content {
+    text-align: center;
+    padding: 50px 34px;
+    background: var(--sp-purple);
+    border-radius: 24px;
+    box-shadow: 8px 8px 0 var(--sp-bg-deep);
+  }
+
+  .sp-cta-title {
+    margin: 0 0 12px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 34px;
+    color: #fff;
+  }
+
+  .sp-cta-sub {
+    margin: 0 0 28px;
+    font-size: 17px;
+    color: #e3d4ff;
+  }
+
+  .sp-cta-row {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  /* ===================== Footer ===================== */
+  .sp-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 26px 34px;
+    background: var(--sp-bg-darkest);
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .sp-footer-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 20px;
+    color: #fff;
+    text-decoration: none;
+  }
+
+  .sp-footer-plus {
+    color: var(--sp-cyan);
+  }
+
+  .sp-footer-links {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .sp-footer-links a {
+    color: var(--sp-ink-muted);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .sp-footer-links a:hover {
+    color: var(--sp-cyan);
+  }
+
+  .sp-footer-by {
+    font-family: var(--font-display);
+    font-weight: 500;
+    font-size: 13px;
+    color: var(--sp-ink-dim);
+  }
+
+  .sp-footer-by a {
+    color: var(--sp-cyan);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  /* ===================== Responsive ===================== */
+  @media (max-width: 760px) {
+    .sp-hero {
+      padding: 36px 22px 12px;
+    }
+
+    .sp-hero-title {
+      font-size: 46px;
+    }
+
+    .sp-nav {
+      padding: 16px 20px;
+    }
+
+    .sp-nav-links {
+      gap: 14px;
+      font-size: 14px;
+    }
+
+    .sp-setup-item {
+      flex-direction: column;
+      gap: 12px;
+      padding: 22px 20px;
+    }
+
+    .sp-cta-title {
+      font-size: 26px;
+    }
+
+    .sp-footer {
+      flex-direction: column;
+      text-align: center;
+    }
+
+    .sp-btn {
+      justify-content: center;
+    }
+  }
+</style>

--- a/src/pages/bot/setup.astro
+++ b/src/pages/bot/setup.astro
@@ -10,7 +10,7 @@ import Twitch from "../../components/Icons/Twitch.astro";
 
 <WosBaseLayout
   title="Set up WoS+ Bot | Twitch Chatbot for Words on Stream"
-  description="You authorized WoS+ Bot. Follow these steps to finish setting it up in your Twitch stream: verify the bot, mod it, and connect your Words on Stream mirror link."
+  description="Finish setting up WoS+ Bot in your Twitch stream: verify the bot, mod it, and connect your Words on Stream mirror link."
   keywords="words on stream, wos, chatbot, twitch bot, wos plus bot, setup, mirror link, mod the bot"
 >
   <div class="sp-bot">
@@ -29,15 +29,14 @@ import Twitch from "../../components/Icons/Twitch.astro";
       <div class="sp-hero-content">
         <span class="sp-hero-badge">
           <Twitch width={16} height={16} />
-          Authorization complete
+          After you authorize the bot
         </span>
         <h1 class="sp-hero-title">
           FINISH <span class="sp-hero-accent">SETUP</span>
         </h1>
         <p class="sp-hero-sub">
-          WoS+ Bot is authorized for your channel. Three short steps in your
-          own Twitch chat and it will start tracking your Words on Stream
-          games.
+          Four short steps in your own Twitch chat and WoS+ Bot will start
+          tracking your Words on Stream games.
         </p>
       </div>
     </section>

--- a/tests/e2e/bot-setup.spec.ts
+++ b/tests/e2e/bot-setup.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { blockExternalNetwork } from './e2e-harness';
+
+/**
+ * Post-authorization chatbot setup instructions (issue #178).
+ *
+ * `/bot/setup` is the page the bot service redirects to after a streamer
+ * authorizes WoS+ Bot, so the instructions a streamer needs at that moment
+ * must actually be on it. These assertions pin the four things the issue
+ * names — verify with `!ping`, mod the bot (rate limits + link-posting
+ * moderation), copy the WoS mirror link, then `!mirror set <link>` — rather
+ * than the page's wording around them.
+ */
+
+test('/bot/setup lists the post-authorization steps', async ({ page }) => {
+  await blockExternalNetwork(page);
+  const response = await page.goto('/bot/setup', { waitUntil: 'domcontentloaded' });
+  expect(response?.status()).toBe(200);
+
+  const steps = page.locator('[data-setup-steps]');
+  await expect(steps).toContainText('!ping');
+  await expect(steps).toContainText('/mod WoSPlusBot');
+  await expect(steps).toContainText('!mirror set');
+});
+
+test('/bot links to the setup instructions', async ({ page }) => {
+  await blockExternalNetwork(page);
+  await page.goto('/bot', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.locator('a[href="/bot/setup"]').first()).toBeVisible();
+});

--- a/tests/e2e/bot-setup.spec.ts
+++ b/tests/e2e/bot-setup.spec.ts
@@ -18,6 +18,10 @@ test('/bot/setup lists the post-authorization steps', async ({ page }) => {
   expect(response?.status()).toBe(200);
 
   const steps = page.locator('[data-setup-steps]');
+  // The hero counts the steps in prose ("Four short steps"), which silently
+  // goes stale if a step is added or merged. Pin the rendered count so the
+  // two can't drift apart unnoticed.
+  await expect(steps.locator('li.sp-setup-item')).toHaveCount(4);
   await expect(steps).toContainText('!ping');
   await expect(steps).toContainText('/mod WoSPlusBot');
   await expect(steps).toContainText('!mirror set');

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -18,7 +18,7 @@ test('GET /api/health returns 200 through the real Workers runtime', async ({ re
   expect(body).toMatchObject({ status: 'ok' });
 });
 
-for (const path of ['/', '/player', '/streamer']) {
+for (const path of ['/', '/player', '/streamer', '/bot', '/bot/setup']) {
   test(`${path} loads without unexpected console errors`, async ({ page }) => {
     await blockExternalNetwork(page);
     const { consoleErrors, unexpectedRequestFailures } = collectUnexpectedFailures(page);


### PR DESCRIPTION
## What changed

Adds `/bot/setup`, a step-by-step page for streamers who have just authorized WoS+ Bot, and links it from `/bot`. Closes #178.

The steps, in the order the issue describes them:

1. **Verify the bot is in chat** — `!ping` → `Pong!`, with what to do if it stays quiet.
2. **Mod the bot** — `/mod WoSPlusBot`, covering both reasons from the issue comments: Twitch rate-limits non-mod accounts that send a lot of messages, and link-posting moderation otherwise times out or bans the bot when it posts board/word links.
3. **Copy the Words on Stream mirror link** from the WoS settings menu.
4. **Send `!mirror set <your mirror link>`** in chat and look for the bot's confirmation reply.

Also corrects `/bot`'s "Zero configuration — no setup needed" feature card and step 2, which were the source of the confusion the issue describes: authorization alone does not connect a game.

**Paired change in the bot service:** clarkio/wos-plus-bot#51 rewrites the OAuth success page so it says "You're not done yet" and links here, instead of "The bot will now join your chat. You can close this window." That is what puts the instructions in front of the streamer at the moment they authorize, as the issue asks. **Merge/deploy this PR first** — the bot's link 404s until this page is live.

The issue's two screenshots (the WoS settings menu, the bot's confirmation message) are described in text rather than hotlinked from GitHub's user-attachment CDN. Happy to add local copies under `public/` if you'd prefer the visuals.

## Verification

- [x] Spec in `specs/` added or updated — **N/A**: no behavioural contract change; this is static marketing/docs content, no `src/scripts` or API behaviour touched.
- [x] Tests written or updated *before or with* the implementation — E2E specs committed alongside; `tests/e2e/bot-setup.spec.ts` pins the three commands (`!ping`, `/mod WoSPlusBot`, `!mirror set`) and `/bot`'s link to the page, and the smoke path loop now includes `/bot` and `/bot/setup`.
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally

```
check:  Result (65 files): 0 errors, 0 warnings, 15 hints
lint:   eslint . --max-warnings 0 — clean
tests:  coverage 91.46% stmts / 87.84% branches / 89% funcs / 92.11% lines
        (all above the enforced floors; unchanged by this PR — no src/**/*.ts touched)
build:  prerendered /bot/setup/index.html, /bot, /player, /streamer, / — Complete!
e2e:    pnpm run test:e2e — 12 passed (was 10)
```

- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: **none**
- [x] Code authored with AI assistance: **yes**

## Notes for the reviewer

- `CLAUDE.md` §9's E2E scope list is updated in this PR to name the new paths, per §6.
- The new page carries its own scoped styles mirroring `bot.astro`'s look rather than extracting a shared component — one concern per PR; a shared bot-page layout would be a reasonable follow-up if a third page appears.
- Step 3 states the mirror link's shape as `https://wos.gg/r/<uuid>`, taken from `src/scripts/mirror-url.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated bot setup guide with authorization confirmation, Twitch configuration steps, verification commands, moderator permissions, mirror-link setup, and troubleshooting guidance.
  * Added navigation from the bot page to the setup guide.
  * Expanded quick-setup instructions and added links to detailed guidance.
* **Tests**
  * Added end-to-end coverage for the bot setup page, navigation, page loading, and console/request health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->