### PR TITLE
Consolidate board ID validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,6 +242,7 @@ Required in **Cloudflare Pages dashboard** (not .env):
 - **No framework state**: Pure DOM manipulation via `document.getElementById()`
 - **localStorage keys**: Prefixed pattern `pb_${channel}`, `pb_${channel}_${date}`, `clears_${channel}_${date}`
 - Missing required params triggers settings dialog automatically
+- **Board IDs**: Normalize and validate with `validateBoardName` from `src/lib/board-utils.ts`; do not duplicate the 4–12 letter rule in callers
 
 ### UI Rendering
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The shape you need to know before touching code:
 | Web Workers | `src/scripts/wos-worker.ts`, `src/scripts/twitch-chat-worker.ts` | `postMessage` only; no DOM, no shared state |
 | Dictionary / word matching | `src/scripts/wos-words.ts` | The crown jewels. Highest-risk module, lowest coverage. |
 | API routes | `src/pages/api/**` | Must `export const prerender = false`; env via `locals.runtime.env`; CORS via `src/lib/cors.ts` |
-| Shared helpers | `src/lib/**` | API responses in `api-utils.ts`; Supabase clients in `supabase.ts`; CORS in `cors.ts` |
+| Shared helpers | `src/lib/**` | Board validation in `board-utils.ts`; API responses in `api-utils.ts`; Supabase clients in `supabase.ts`; CORS in `cors.ts` |
 | Tests | `tests/unit/`, `tests/acceptance/`, `tests/property/` | Vitest 4 + happy-dom; setup in `tests/setup.ts`. Two streams — see §7 |
 | E2E smoke | `tests/e2e/` | Playwright, against a real `wrangler dev` runtime. Separate from Vitest — see §9 |
 | Behavioural contract | `specs/` | Human-owned. Acceptance tests cite it; open questions indexed in [specs/README.md](specs/README.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,8 @@ Prefer a failing build over a paragraph of good advice.
   test in `tests/acceptance/`, so the stub file and the empty
   `tests/integration/` directory were deleted rather than left as a decoy.
 - `pnpm run check` is **clean** (0 errors, 0 warnings; some hints remain).
-- Coverage: **91.49% statements / 87.86% branches / 89.11% functions /
- 92.16% lines**. It counts **all** files under `src/**/*.ts`, so an untested
+- Coverage: **91.39% statements / 87.55% branches / 89.17% functions /
+ 92.05% lines**. It counts **all** files under `src/**/*.ts`, so an untested
   module appears at 0% instead of being invisible.
   - `src/pages/api/**`, `src/lib/cors.ts` and `src/lib/board-utils.ts` are at
     **100%**, covered by the acceptance stream.

--- a/src/scripts/db-service.ts
+++ b/src/scripts/db-service.ts
@@ -1,4 +1,4 @@
-import { findRedundantWords, hasInvalidWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel } from '../lib/board-utils';
+import { findRedundantWords, hasInvalidWords, hasRedundantWords, normalizeLanguageCode, normalizeTwitchChannel, validateBoardName } from '../lib/board-utils';
 
 export interface ChannelStats {
   allTimePersonalBest: number;
@@ -145,26 +145,26 @@ function storedBoardCorruptionReason(board: Board | null, boardId: string): 'red
   return null;
 }
 
+function clientBoardIdWarning(error: string): string {
+  if (error === 'Board ID is required') {
+    return 'boardId must be a non-empty string.';
+  }
+  if (error === 'Invalid board ID format. Only letters are allowed.') {
+    return 'boardId contains invalid characters. Only letters are allowed.';
+  }
+  if (error === 'Invalid board ID length. Must be between 4 and 12 characters.') {
+    return 'boardId length must be between 4 and 12 characters.';
+  }
+  return error;
+}
+
 export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: string, languageCode?: string) {
-  // Validate boardId is a string and not too long
-  if (typeof boardId !== 'string' || boardId.length === 0) {
-    console.warn('Cannot save board: boardId must be a non-empty string.');
+  const boardName = validateBoardName(boardId);
+  if ('error' in boardName) {
+    console.warn(`Cannot save board: ${clientBoardIdWarning(boardName.error)}`);
     return;
   }
-
-  // Clean up big word (remove spaces if stored as "W O R D")
-  const cleanBoardId = boardId.replace(/\s+/g, "").toUpperCase();
-
-  // Security validation: only allow alphabetic characters
-  if (!/^[A-Z]+$/.test(cleanBoardId)) {
-    console.warn('Cannot save board: boardId contains invalid characters. Only letters are allowed.');
-    return;
-  }
-
-  if (cleanBoardId.length < 4 || cleanBoardId.length > 12) {
-    console.warn('Cannot save board: boardId length must be between 4 and 12 characters.');
-    return;
-  }
+  const { cleanId: cleanBoardId } = boardName;
 
   // Validate slots array
   if (!Array.isArray(slots) || slots.length === 0) {
@@ -310,25 +310,12 @@ export async function saveBoard(boardId: string, slots: Slot[], twitchChannel?: 
 }
 
 export async function fetchBoard(boardId: string): Promise<Board | null> {
-  if (typeof boardId !== 'string' || boardId.length === 0) {
-    console.warn('Cannot fetch board: boardId must be a non-empty string.');
+  const boardName = validateBoardName(boardId);
+  if ('error' in boardName) {
+    console.warn(`Cannot fetch board: ${clientBoardIdWarning(boardName.error)}`);
     return null;
   }
-
-  // Clean up big word (remove spaces if stored as "W O R D")
-  const cleanBoardId = boardId.replace(/\s+/g, "").toUpperCase();
-
-  // Security validation: only allow alphabetic characters
-  if (!/^[A-Z]+$/.test(cleanBoardId)) {
-    console.warn('Cannot fetch board: boardId contains invalid characters. Only letters are allowed.');
-    return null;
-  }
-
-  // Validate length to prevent abuse
-  if (cleanBoardId.length < 4 || cleanBoardId.length > 12) {
-    console.warn('Cannot fetch board: boardId length must be between 4 and 12 characters.');
-    return null;
-  }
+  const { cleanId: cleanBoardId } = boardName;
 
   try {
     const url = `/api/boards/${encodeURIComponent(cleanBoardId)}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Resolves #132 by replacing the duplicated `saveBoard` and `fetchBoard` normalization/validation sequences with the existing `validateBoardName()` helper already used by the API route. This uses the richer helper introduced after the issue was written rather than adding a second `normalizeBoardId` validator, and preserves the client’s existing warning text.

## Verification

- [x] Spec in `specs/` N/A — this is a behavior-preserving refactor
- [x] Existing unit and acceptance tests cover the consolidated rules and all three call paths
- [x] `pnpm run check && pnpm run lint && pnpm run test:coverage && pnpm run build` pass locally
- [x] No existing test weakened, skipped, or deleted
- [x] New dependencies: none
- [x] Code authored with AI assistance: yes

Local gate results (Node 22.22.2): 0 check errors/warnings, lint clean, 701 tests passed with 3 existing todos, coverage 91.39% statements / 87.55% branches / 89.17% functions / 92.05% lines, production build passed.

## Notes for the reviewer

The issue’s proposed `normalizeBoardId(): string | null` predates `validateBoardName()`, added by #162. Reusing the latter keeps one source of truth while retaining precise API error responses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7096c8e1-dea8-4021-ba5c-f4eab9d66fcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7096c8e1-dea8-4021-ba5c-f4eab9d66fcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized board ID validation and normalization when saving or loading boards.
  * Improved client-facing warnings for invalid board IDs, including clearer handling of validation errors.

* **Documentation**
  * Updated project guidance to clarify board validation behavior and refreshed coverage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->